### PR TITLE
fix: upgrade ts-node to tix resolveTypeReferenceDirective issue

### DIFF
--- a/src/clickup-cdk.ts
+++ b/src/clickup-cdk.ts
@@ -36,6 +36,7 @@ export module clickupCdk {
       // Theoretically we should be able to just take a default here, but for some reason this is required.
       const repositoryUrl = options.repositoryUrl || `https://github.com/${name.substring(1)}.git`;
       super(merge(clickupTs.defaults, options, { authorName, authorAddress, name, repositoryUrl }));
+      clickupTs.fixTsNodeDeps(this.package);
       codecov.addCodeCovYml(this);
       codecov.addCodeCovOnRelease(this);
     }
@@ -57,6 +58,7 @@ export module clickupCdk {
   export class ClickUpCdkTypeScriptApp extends awscdk.AwsCdkTypeScriptApp {
     constructor(options: ClickUpCdkTypeScriptAppOptions) {
       super(merge(clickupTs.defaults, defaults, options, { sampleCode: false }));
+      clickupTs.fixTsNodeDeps(this.package);
       new AppSampleCode(this);
       new SampleReadme(this, {
         contents: `[![codecov](https://codecov.io/gh/time-loop/WRITEME/branch/main/graph/badge.svg?token=WRITEME)](https://codecov.io/gh/time-loop/WRITEME)

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -1,4 +1,5 @@
 import { javascript, typescript } from 'projen';
+import { NodePackage } from 'projen/lib/javascript';
 import merge from 'ts-deepmerge';
 import { codecov } from './codecov';
 
@@ -103,8 +104,19 @@ export module clickupTs {
   export class ClickUpTypeScriptProject extends typescript.TypeScriptProject {
     constructor(options: ClickUpTypeScriptProjectOptions) {
       super(merge(defaults, { deps }, options, { name: normalizeName(options.name) }));
+      fixTsNodeDeps(this.package);
       codecov.addCodeCovYml(this);
       codecov.addCodeCovOnRelease(this);
     }
+  }
+
+  /**
+   * Resolves resolveTypeReferenceDirective error. It can't be done in
+   * clickupTs.devDeps (something in TypeScriptProject base class constructor
+   * gives clickupTs.devDeps lower priority than to the deps derived from other
+   * packages where ts-node is mentioned?).
+   */
+  export function fixTsNodeDeps(pkg: NodePackage) {
+    pkg.addDevDeps('ts-node@^10');
   }
 }

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -34,6 +34,7 @@ Object {
     "projen": "*",
     "standard-version": "^9",
     "ts-jest": "*",
+    "ts-node": "^10",
     "typescript": "*",
   },
   "engines": Object {
@@ -178,7 +179,7 @@ Object {
     "projen": "*",
     "standard-version": "^9",
     "ts-jest": "*",
-    "ts-node": "^9",
+    "ts-node": "^10",
     "typescript": "*",
   },
   "engines": Object {

--- a/test/__snapshots__/clickup-ts.test.ts.snap
+++ b/test/__snapshots__/clickup-ts.test.ts.snap
@@ -200,6 +200,7 @@ Object {
     "projen": "*",
     "standard-version": "^9",
     "ts-jest": "*",
+    "ts-node": "^10",
     "typescript": "*",
   },
   "engines": Object {


### PR DESCRIPTION
This is my attempt to solve the problem.

But unfortunately it does not: despite myapp-cdk/.projen/deps.json file generated has ts-node v10, the consequent run of `cd myapp-cdk && yarn projen` erases it back to v9. The only bullet-proof way to solve is to add `project.package.addDevDeps('ts-node@^10');` to myapp-cdk/.projenrc.js as you mentioned in Slack, but I can't find a way to modify the generated myapp-cdk/.projenrc.js file from inside clickup-cdk.ts.

**Test plan**

```
(cd clickup-projen && yarn build) && \
(rm -rf myapp-cdk; mkdir myapp-cdk; cd myapp-cdk; \
projen new --from ~/git/clickup-projen/dist/js/clickup-projen@0.0.0.jsii.tgz clickupcdk_clickupcdktypescriptapp)
```

