### PR TITLE
fix: add .idea to gitignore

### DIFF
--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -46,7 +46,7 @@ export module clickupTs {
         run: 'export FORCE_PREBUILT_LAMBDA=1',
       },
     ],
-    gitignore: ['/.npmrc'],
+    gitignore: ['/.npmrc', '.idea'],
 
     minNodeVersion: '14.18.0', // Required by eslint-import-resolver-typescript@3.3.0
     workflowNodeVersion: '14.18.0',


### PR DESCRIPTION
Adds `.idea` to gitignore for webstorm users. Otherwise I'm gonna end up checking this in by accident:
<img width="625" alt="CleanShot 2022-08-26 at 12 47 33@2x" src="https://user-images.githubusercontent.com/6425649/186896842-c1bbf2b0-ba30-4d87-9776-502eff668118.png">
