### PR TITLE
fix(eng-prod): DD Release Event Job Must Depend On release Job [INFRA-256]

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,11 +37,13 @@
   },
   "ignorePatterns": [
     "*.js",
-    "!.projenrc.js",
+    "!.projenrc.ts",
     "*.d.ts",
     "node_modules/",
     "*.generated.ts",
-    "coverage"
+    "coverage",
+    "!.projenrc.ts",
+    "!projenrc/**/*.ts"
   ],
   "rules": {
     "prettier/prettier": [
@@ -55,7 +57,10 @@
       {
         "devDependencies": [
           "**/test/**",
-          "**/build-tools/**"
+          "**/build-tools/**",
+          "**/projenrc/**",
+          ".projenrc.ts",
+          "projenrc/**/*.ts"
         ],
         "optionalDependencies": false,
         "peerDependencies": true
@@ -130,7 +135,7 @@
   "overrides": [
     {
       "files": [
-        ".projenrc.js"
+        ".projenrc.ts"
       ],
       "rules": {
         "@typescript-eslint/no-require-imports": "off",

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -25,4 +25,4 @@ jobs:
             feat
             fix
             chore
-          requireScope: false
+          requireScope: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,28 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: npm.pkg.github.com
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  send_datadog_release_event:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CI: "true"
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Output event metadata
+        id: event_metadata
+        run: |-
+          echo ::set-output name=release_tag::"$(cat dist/releasetag.txt)"
+          echo ::set-output name=repo_name::"$(echo ${{ github.repository }} | cut -d'/' -f2)"
+      - name: Datadog Release Event
+        uses: Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948
+        with:
+          datadog_api_key: ${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
+          datadog_us: true
+          event_title: Released ${{ steps.event_metadata.outputs.repo_name }} version ${{ steps.event_metadata.outputs.release_tag }}
+          event_text: Released ${{ steps.event_metadata.outputs.repo_name }} version ${{ steps.event_metadata.outputs.release_tag }}
+          event_priority: normal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,28 +99,3 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: npm.pkg.github.com
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  send_datadog_release_event:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      CI: "true"
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: build-artifact
-          path: dist
-      - name: Output event metadata
-        id: event_metadata
-        run: |-
-          echo ::set-output name=release_tag::"$(cat dist/releasetag.txt)"
-          echo ::set-output name=repo_name::"$(echo ${{ github.repository }} | cut -d'/' -f2)"
-      - name: Datadog Release Event
-        uses: Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948
-        with:
-          datadog_api_key: ${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
-          datadog_us: true
-          event_title: Released ${{ steps.event_metadata.outputs.repo_name }} version ${{ steps.event_metadata.outputs.release_tag }}
-          event_text: Released ${{ steps.event_metadata.outputs.repo_name }} version ${{ steps.event_metadata.outputs.release_tag }}
-          event_priority: normal

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -99,6 +99,10 @@
       "type": "build"
     },
     {
+      "name": "ts-node",
+      "type": "build"
+    },
+    {
       "name": "typescript",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -96,7 +96,7 @@
       "description": "Synthesize project files",
       "steps": [
         {
-          "exec": "node .projenrc.js"
+          "exec": "ts-node --project tsconfig.dev.json .projenrc.ts"
         }
       ]
     },
@@ -126,7 +126,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.js"
+          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools projenrc .projenrc.ts"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -21,6 +21,11 @@ const project = new cdk.JsiiProject({
     // TODO: we should instead be using an app for auth.
     // projenCredentials: github.GithubCredentials.fromApp(writeme),
     projenCredentials: github.GithubCredentials.fromPersonalAccessToken(),
+    pullRequestLintOptions: {
+      // Enforce conventional commits https://www.conventionalcommits.org/
+      // https://github.com/marketplace/actions/semantic-pull-request
+      semanticTitleOptions: { requireScope: true },
+    },
   },
 
   // We don't depend on any private resources.

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,5 +1,4 @@
 import { cdk, github, javascript, YamlFile } from 'projen';
-import { datadog } from './src/datadog';
 
 const bundledDeps = ['ts-deepmerge'];
 
@@ -115,5 +114,4 @@ new YamlFile(project, 'codecov.yml', {
   },
 });
 
-datadog.addReleaseEvent(project);
 project.synth();

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,9 +1,11 @@
-const { cdk, github, javascript, YamlFile } = require('projen');
+import { cdk, github, javascript, YamlFile } from 'projen';
+import { datadog } from './src/datadog';
 
 const bundledDeps = ['ts-deepmerge'];
 
 const project = new cdk.JsiiProject({
   name: '@time-loop/clickup-projen',
+  author: 'ClickUp DevOps',
   authorAddress: 'devops@clickup.com',
   authorName: 'ClickUp DevOps',
   authorOrganization: true,
@@ -49,6 +51,7 @@ const project = new cdk.JsiiProject({
       trailingComma: javascript.TrailingComma.ALL,
     },
   },
+  projenrcTs: true,
   stale: true,
 
   jestOptions: {
@@ -58,9 +61,6 @@ const project = new cdk.JsiiProject({
   },
   codeCov: true,
   codeCovTokenSecret: 'CODECOV_TOKEN',
-  // Enforce conventional commits https://www.conventionalcommits.org/
-  // https://github.com/marketplace/actions/semantic-pull-request
-  semanticTitleOptions: { requireScope: true },
 });
 
 new YamlFile(project, 'codecov.yml', {
@@ -110,4 +110,5 @@ new YamlFile(project, 'codecov.yml', {
   },
 });
 
+datadog.addReleaseEvent(project);
 project.synth();

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "projen": "^0.61.37",
     "standard-version": "^9",
     "ts-jest": "^27",
+    "ts-node": "^10.9.1",
     "typescript": "^4.8.2"
   },
   "peerDependencies": {

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -53,10 +53,13 @@ export module datadog {
   export function addReleaseEvent(project: NodeProject, opts?: ReleaseEventOptions) {
     project.release?.addJobs({
       send_datadog_release_event: {
+        name: 'Datadog Release Event',
         permissions: {
           contents: JobPermission.READ,
         },
         runsOn: ['ubuntu-latest'],
+        needs: ['release'],
+        if: 'needs.release.outputs.latest_commit == github.sha',
         env: {
           CI: 'true',
         },
@@ -77,7 +80,7 @@ export module datadog {
 echo ::set-output name=repo_name::"$(echo \${{ github.repository }} | cut -d'/' -f2)"`,
           },
           {
-            name: 'Datadog Release Event',
+            name: 'Send Event',
             // https://github.com/Glennmen/datadog-event-action/releases/tag/1.1.0
             uses: 'Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948',
             with: setReleaseEventInputs(opts),

--- a/test/__snapshots__/datadog.test.ts.snap
+++ b/test/__snapshots__/datadog.test.ts.snap
@@ -63,11 +63,14 @@ jobs:
           GITHUB_REPOSITORY: \${{ github.repository }}
           GITHUB_REF: \${{ github.ref }}
   send_datadog_release_event:
+    name: Datadog Release Event
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       CI: \\"true\\"
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
@@ -79,7 +82,7 @@ jobs:
         run: |-
           echo ::set-output name=release_tag::\\"$(cat dist/releasetag.txt)\\"
           echo ::set-output name=repo_name::\\"$(echo \${{ github.repository }} | cut -d'/' -f2)\\"
-      - name: Datadog Release Event
+      - name: Send Event
         uses: Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948
         with:
           datadog_api_key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
@@ -153,11 +156,14 @@ jobs:
           GITHUB_REPOSITORY: \${{ github.repository }}
           GITHUB_REF: \${{ github.ref }}
   send_datadog_release_event:
+    name: Datadog Release Event
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       CI: \\"true\\"
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
@@ -169,7 +175,7 @@ jobs:
         run: |-
           echo ::set-output name=release_tag::\\"$(cat dist/releasetag.txt)\\"
           echo ::set-output name=repo_name::\\"$(echo \${{ github.repository }} | cut -d'/' -f2)\\"
-      - name: Datadog Release Event
+      - name: Send Event
         uses: Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948
         with:
           datadog_api_key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
@@ -244,11 +250,14 @@ jobs:
           GITHUB_REPOSITORY: \${{ github.repository }}
           GITHUB_REF: \${{ github.ref }}
   send_datadog_release_event:
+    name: Datadog Release Event
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       CI: \\"true\\"
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v3
@@ -260,7 +269,7 @@ jobs:
         run: |-
           echo ::set-output name=release_tag::\\"$(cat dist/releasetag.txt)\\"
           echo ::set-output name=repo_name::\\"$(echo \${{ github.repository }} | cut -d'/' -f2)\\"
-      - name: Datadog Release Event
+      - name: Send Event
         uses: Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948
         with:
           datadog_api_key: TEST_API_KEY

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -27,7 +27,9 @@
   "include": [
     ".projenrc.js",
     "src/**/*.ts",
-    "test/**/*.ts"
+    "test/**/*.ts",
+    ".projenrc.ts",
+    "projenrc/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,6 +290,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@eslint/eslintrc@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.1.tgz#de0807bfeffc37b964a7d0400e0c348ce5a2543d"
@@ -561,6 +568,14 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
@@ -746,6 +761,26 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -1035,12 +1070,17 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.2.4, acorn@^8.8.0:
+acorn@^8.2.4, acorn@^8.4.1, acorn@^8.8.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
@@ -1162,6 +1202,11 @@ are-we-there-yet@^3.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1838,6 +1883,11 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -2018,6 +2068,11 @@ diff-sequences@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
   integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4147,7 +4202,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -5803,6 +5858,25 @@ ts-jest@^27:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -6004,6 +6078,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^8.1.0:
   version "8.1.1"
@@ -6244,6 +6323,11 @@ yargs@^16.0.0, yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Task: https://staging.clickup.com/t/333/INFRA-256

Fixes #60 
- chore: Convert `.projenrc.js` to `.projenrc.ts` so we can import TS modules into the project AND reveal problems with the configuration itself
- fix: Correct the placement of invalid key `semanticTitleOptions` to start actually enforcing scope requirement
- fix: DD release event job must depend on release job for the build artifact...cannot run in parallel