### PR TITLE
chore(core-services): update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ We do not as yet have a naming convention for TypeScript libraries.
 
 ### CdkApp
 
-If you aren't sure, **this is probably what you are here for**.
+If you aren't sure, **this is probably what you are here for**. 
+
+Make sure you are using the appropriate node version with `nvm use --lts`. 
+
 When creating new cdk apps:
 
 ```bash


### PR DESCRIPTION
Most backend engineers have their Node version set to 12 since that is what we use on ECS/beanstalks. The projen setup will not work with Node 12 so I am adding a reminder to do `nvm use --lts` before using projen. 