### PR TITLE
fix(eng-prod): CSON is used for the event_tags, not JSON [INFRA-53]

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -107,12 +107,20 @@
       "type": "build"
     },
     {
+      "name": "cson-parser",
+      "type": "bundled"
+    },
+    {
       "name": "ts-deepmerge",
       "type": "bundled"
     },
     {
       "name": "projen",
       "type": "peer"
+    },
+    {
+      "name": "cson-parser",
+      "type": "runtime"
     },
     {
       "name": "projen",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,6 +1,6 @@
 import { cdk, github, javascript, YamlFile } from 'projen';
 
-const bundledDeps = ['ts-deepmerge'];
+const bundledDeps = ['ts-deepmerge', 'cson-parser'];
 
 const project = new cdk.JsiiProject({
   name: '@time-loop/clickup-projen',

--- a/package.json
+++ b/package.json
@@ -64,10 +64,12 @@
     "projen": "^0.61.37"
   },
   "dependencies": {
+    "cson-parser": "^4.0.9",
     "projen": "^0.61.37",
     "ts-deepmerge": "^2.0.7"
   },
   "bundledDependencies": [
+    "cson-parser",
     "ts-deepmerge"
   ],
   "main": "lib/index.js",

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -1,3 +1,4 @@
+import { stringify } from 'cson-parser';
 import { JobPermission } from 'projen/lib/github/workflows-model';
 import { NodeProject } from 'projen/lib/javascript';
 
@@ -105,7 +106,7 @@ export module datadog {
 
   function parseReleaseEventTags(tags: ReleaseEventTags): string {
     const tagsArr = Object.keys(tags).map((key) => `${key}:${tags[key]}`);
-    return JSON.stringify(tagsArr);
+    return stringify(tagsArr);
   }
 
   function setReleaseEventInputs(project: NodeProject, opts?: ReleaseEventOptions): ReleaseEventActionInputs {

--- a/test/__snapshots__/datadog.test.ts.snap
+++ b/test/__snapshots__/datadog.test.ts.snap
@@ -88,7 +88,7 @@ jobs:
           event_title: Released test-cdk version \${{ steps.event_metadata.outputs.release_tag }}
           event_text: Released test-cdk version \${{ steps.event_metadata.outputs.release_tag }}
           event_priority: normal
-          event_tags: '[\\"project:test-cdk\\",\\"release:true\\",\\"version:\${{ steps.event_metadata.outputs.release_tag }}\\",\\"actor:\${{ github.actor }}\\",\\"TestKey:TestVal\\",\\"TestKey2:TestVal2\\"]'
+          event_tags: \\"['project:test-cdk','release:true','version:\${{ steps.event_metadata.outputs.release_tag }}','actor:\${{ github.actor }}','TestKey:TestVal','TestKey2:TestVal2']\\"
 "
 `;
 
@@ -180,7 +180,7 @@ jobs:
           event_title: Released test-cdk version \${{ steps.event_metadata.outputs.release_tag }}
           event_text: Released test-cdk version \${{ steps.event_metadata.outputs.release_tag }}
           event_priority: normal
-          event_tags: '[\\"project:test-cdk\\",\\"release:true\\",\\"version:\${{ steps.event_metadata.outputs.release_tag }}\\",\\"actor:\${{ github.actor }}\\"]'
+          event_tags: \\"['project:test-cdk','release:true','version:\${{ steps.event_metadata.outputs.release_tag }}','actor:\${{ github.actor }}']\\"
 "
 `;
 
@@ -272,7 +272,7 @@ jobs:
           event_title: Test title
           event_text: Test event text
           event_priority: low
-          event_tags: '[\\"project:test-cdk\\",\\"release:true\\",\\"version:\${{ steps.event_metadata.outputs.release_tag }}\\",\\"actor:\${{ github.actor }}\\",\\"TestTag1:TestTagVal1\\",\\"TestTag2:TestTagVal2\\"]'
+          event_tags: \\"['project:test-cdk','release:true','version:\${{ steps.event_metadata.outputs.release_tag }}','actor:\${{ github.actor }}','TestTag1:TestTagVal1','TestTag2:TestTagVal2']\\"
 "
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,6 +1592,11 @@ codemaker@^1.66.0:
     decamelize "^5.0.1"
     fs-extra "^10.1.0"
 
+coffeescript@1.12.7:
+  version "1.12.7"
+  resolved "https://registry.yarnpkg.com/coffeescript/-/coffeescript-1.12.7.tgz#e57ee4c4867cf7f606bfc4a0f2d550c0981ddd27"
+  integrity sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==
+
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
@@ -1903,6 +1908,13 @@ crypto-random-string@^4.0.0:
   integrity sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==
   dependencies:
     type-fest "^1.0.1"
+
+cson-parser@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/cson-parser/-/cson-parser-4.0.9.tgz#eef0cf77edd057f97861ef800300c8239224eedb"
+  integrity sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==
+  dependencies:
+    coffeescript "1.12.7"
 
 cssom@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
Fixes #64 

- fix: JSON was previously being passed into the `event_tags` input, but this is invalid because of the double quotes. Instead, we need to pass in CSON which uses single quotes. Note their [Event Tags section](https://github.com/Glennmen/datadog-event-action#event-tags), which is not valid JSON.

Tested via `act`, screenshot below:
![Screen Shot 2022-09-07 at 3 11 37 PM](https://user-images.githubusercontent.com/20311786/188992715-cc02cdb9-0827-4498-b52f-05d164578d80.png)
