### PR TITLE
fix(devops): add self as devDep

### DIFF
--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -7,7 +7,14 @@ export module clickupTs {
   // This is not included in defaults because other projects may not always want to require it.
   export const deps = ['@time-loop/clickup-projen'];
 
-  export const devDeps = ['esbuild', 'eslint-config-prettier', 'eslint-plugin-prettier', 'jsii-release', 'prettier'];
+  export const devDeps = [
+    '@time-loop/clickup-projen',
+    'esbuild',
+    'eslint-config-prettier',
+    'eslint-plugin-prettier',
+    'jsii-release',
+    'prettier',
+  ];
 
   export const defaults = {
     authorAddress: 'devops@clickup.com',

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -9,6 +9,7 @@ Object {
     "organization": true,
   },
   "devDependencies": Object {
+    "@time-loop/clickup-projen": "*",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -161,6 +162,7 @@ Object {
     "multi-convention-namer": "*",
   },
   "devDependencies": Object {
+    "@time-loop/clickup-projen": "*",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/test/__snapshots__/clickup-ts.test.ts.snap
+++ b/test/__snapshots__/clickup-ts.test.ts.snap
@@ -180,6 +180,7 @@ Object {
     "@time-loop/clickup-projen": "*",
   },
   "devDependencies": Object {
+    "@time-loop/clickup-projen": "*",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",


### PR DESCRIPTION
I've seen a number of repos which are adding `clickup-projen` as a devDep. So...