### PR TITLE
feat(infra): Automatically add peerDeps as pinned devDeps [CLK-188197]

### DIFF
--- a/src/clickup-cdk.ts
+++ b/src/clickup-cdk.ts
@@ -90,6 +90,7 @@ export module clickupCdk {
           authorAddress,
           name,
           repositoryUrl,
+          // Set is used here to ensure uniqueness
           devDeps: [...new Set(getPinnedDeps(options.peerDeps ?? []))],
         }),
       );

--- a/src/clickup-cdk.ts
+++ b/src/clickup-cdk.ts
@@ -4,6 +4,7 @@ import merge from 'ts-deepmerge';
 import { clickupTs } from './clickup-ts';
 import { codecov } from './codecov';
 import { datadog } from './datadog';
+import { getPinnedDeps } from './helpers';
 
 export module clickupCdk {
   export const deps = [
@@ -83,7 +84,15 @@ export module clickupCdk {
       const authorAddress = options.authorAddress || clickupTs.defaults.authorAddress;
       // Theoretically we should be able to just take a default here, but for some reason this is required.
       const repositoryUrl = options.repositoryUrl || `https://github.com/${name.substring(1)}.git`;
-      super(merge(clickupTs.defaults, options, { authorName, authorAddress, name, repositoryUrl }));
+      super(
+        merge(clickupTs.defaults, options, {
+          authorName,
+          authorAddress,
+          name,
+          repositoryUrl,
+          devDeps: [...new Set(getPinnedDeps(options.peerDeps ?? []))],
+        }),
+      );
       clickupTs.fixTsNodeDeps(this.package);
       codecov.addCodeCovYml(this);
 

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -202,6 +202,7 @@ export module clickupTs {
           defaults,
           { deps },
           options,
+          // Set is used here to ensure uniqueness
           { devDeps: [...new Set(getPinnedDeps(options.peerDeps ?? []))] },
           {
             // Disable projen's built-in docgen class

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -198,18 +198,13 @@ export module clickupTs {
   export class ClickUpTypeScriptProject extends typescript.TypeScriptProject {
     constructor(options: ClickUpTypeScriptProjectOptions) {
       super(
-        merge(
-          defaults,
-          { deps },
-          options,
+        merge(defaults, { deps }, options, {
           // Set is used here to ensure uniqueness
-          {
-            // Disable projen's built-in docgen class
-            devDeps: [...new Set(getPinnedDeps(options.peerDeps ?? []))],
-            docgen: undefined,
-            name: normalizeName(options.name),
-          },
-        ),
+          devDeps: [...new Set(getPinnedDeps(options.peerDeps ?? []))],
+          // Disable projen's built-in docgen class
+          docgen: undefined,
+          name: normalizeName(options.name),
+        }),
       );
       fixTsNodeDeps(this.package);
       codecov.addCodeCovYml(this);

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -203,9 +203,9 @@ export module clickupTs {
           { deps },
           options,
           // Set is used here to ensure uniqueness
-          { devDeps: [...new Set(getPinnedDeps(options.peerDeps ?? []))] },
           {
             // Disable projen's built-in docgen class
+            devDeps: [...new Set(getPinnedDeps(options.peerDeps ?? []))],
             docgen: undefined,
             name: normalizeName(options.name),
           },

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -2,6 +2,7 @@ import { javascript, typescript, Component, JsonFile } from 'projen';
 import { NodePackage } from 'projen/lib/javascript';
 import merge from 'ts-deepmerge';
 import { codecov } from './codecov';
+import { getPinnedDeps } from './helpers';
 
 export module clickupTs {
   // This is not included in defaults because other projects may not always want to require it.
@@ -27,7 +28,6 @@ export module clickupTs {
     npmRegistryUrl: 'https://npm.pkg.github.com',
 
     devDeps,
-
     depsUpgradeOptions: {
       workflowOptions: {
         schedule: javascript.UpgradeDependenciesSchedule.WEEKLY,
@@ -198,11 +198,17 @@ export module clickupTs {
   export class ClickUpTypeScriptProject extends typescript.TypeScriptProject {
     constructor(options: ClickUpTypeScriptProjectOptions) {
       super(
-        merge(defaults, { deps }, options, {
-          // Disable projen's built-in docgen class
-          docgen: undefined,
-          name: normalizeName(options.name),
-        }),
+        merge(
+          defaults,
+          { deps },
+          options,
+          { devDeps: [...new Set(getPinnedDeps(options.peerDeps ?? []))] },
+          {
+            // Disable projen's built-in docgen class
+            docgen: undefined,
+            name: normalizeName(options.name),
+          },
+        ),
       );
       fixTsNodeDeps(this.package);
       codecov.addCodeCovYml(this);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,11 @@
+/**
+ * Strips out ^ and ~ characters from package names in favor of specific
+ * versions.
+ * @param theDeps A list of dependencies (and possibly their versions)
+ * @returns A list of dependencies pinned to a version
+ */
+export function getPinnedDeps(theDeps: string[]): string[] {
+  return theDeps.map((d) => {
+    return d.replace(new RegExp(/~|\^/), '');
+  });
+}

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,0 +1,15 @@
+import { getPinnedDeps } from '../src/helpers';
+
+describe('getPinnedDeps', () => {
+  it('returns empty list when empty', () => {
+    expect(getPinnedDeps([])).toEqual([]);
+  });
+  it('returns same list when no version range is specified', () => {
+    const dynamicDeps = ['ts-deepmerge', '@time-loop/cdk-ecs-fargate', 'fake-pkg'];
+    expect(getPinnedDeps(dynamicDeps)).toEqual(dynamicDeps);
+  });
+  it('returns lowest acceptable versions when version range is specified', () => {
+    const dynamicDeps = ['ts-deepmerge@1.3.4', 'some-fake-pkg@^2.9.8', 'fake-pkg2@~2.5.7'];
+    expect(getPinnedDeps(dynamicDeps)).toEqual(['ts-deepmerge@1.3.4', 'some-fake-pkg@2.9.8', 'fake-pkg2@2.5.7']);
+  });
+});


### PR DESCRIPTION
This resolves the need for us to manually manage `peerDeps` getting added as `devDeps` (to a pinned version) in each individual repo, per JSII requirements.