### PR TITLE
fix(dependencies): remove @time-loop/clickup-projen from dev dependencies

### DIFF
--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -8,14 +8,7 @@ export module clickupTs {
   // This is not included in defaults because other projects may not always want to require it.
   export const deps = ['@time-loop/clickup-projen'];
 
-  export const devDeps = [
-    '@time-loop/clickup-projen',
-    'esbuild',
-    'eslint-config-prettier',
-    'eslint-plugin-prettier',
-    'jsii-release',
-    'prettier',
-  ];
+  export const devDeps = ['esbuild', 'eslint-config-prettier', 'eslint-plugin-prettier', 'jsii-release', 'prettier'];
 
   export const defaults = {
     authorAddress: 'devops@clickup.com',

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -9,7 +9,6 @@ Object {
     "organization": true,
   },
   "devDependencies": Object {
-    "@time-loop/clickup-projen": "*",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -163,7 +162,6 @@ Object {
     "multi-convention-namer": "*",
   },
   "devDependencies": Object {
-    "@time-loop/clickup-projen": "*",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/test/__snapshots__/clickup-ts.test.ts.snap
+++ b/test/__snapshots__/clickup-ts.test.ts.snap
@@ -78,7 +78,6 @@ Object {
     "@time-loop/clickup-projen": "*",
   },
   "devDependencies": Object {
-    "@time-loop/clickup-projen": "*",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",


### PR DESCRIPTION
`@time-loop/clickup-projen` is also listed in dependencies which causes renovate to create 2 separate PRs to upgrade it. Packages only need to be listed in dependencies or dev dependencies and not both, so we remove it from dev dependencies  (removing it from dependencies may break things)