### PR TITLE
fix(renovate): set renovate range strategy to bump

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -67,8 +67,8 @@ const project = new cdk.JsiiProject({
     scheduleInterval: ['before 1am on Monday'],
     ignoreProjen: false,
     overrideConfig: {
-      rangeStrategy: 'bump'
-    }
+      rangeStrategy: 'bump',
+    },
   },
 
   jestOptions: {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -66,6 +66,9 @@ const project = new cdk.JsiiProject({
   renovatebotOptions: {
     scheduleInterval: ['before 1am on Monday'],
     ignoreProjen: false,
+    overrideConfig: {
+      rangeStrategy: 'bump'
+    }
   },
 
   jestOptions: {

--- a/API.md
+++ b/API.md
@@ -5070,6 +5070,7 @@ const clickUpTypeScriptProjectOptions: clickupTs.ClickUpTypeScriptProjectOptions
 | <code><a href="#@time-loop/clickup-projen.clickupTs.ClickUpTypeScriptProjectOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#@time-loop/clickup-projen.clickupTs.ClickUpTypeScriptProjectOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name of the development tsconfig.json file. |
 | <code><a href="#@time-loop/clickup-projen.clickupTs.ClickUpTypeScriptProjectOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
+| <code><a href="#@time-loop/clickup-projen.clickupTs.ClickUpTypeScriptProjectOptions.property.authorAddress">authorAddress</a></code> | <code>string</code> | Email address for project author. |
 | <code><a href="#@time-loop/clickup-projen.clickupTs.ClickUpTypeScriptProjectOptions.property.docgenOptions">docgenOptions</a></code> | <code>@time-loop/clickup-projen.clickupTs.TypedocDocgenOptions</code> | Additional options pertaining to the typedoc config file. |
 
 ---
@@ -6948,6 +6949,18 @@ TypeScript version to use.
 
 NOTE: Typescript is not semantically versioned and should remain on the
 same minor, so we recommend using a `~` dependency (e.g. `~1.2.3`).
+
+---
+
+##### `authorAddress`<sup>Optional</sup> <a name="authorAddress" id="@time-loop/clickup-projen.clickupTs.ClickUpTypeScriptProjectOptions.property.authorAddress"></a>
+
+```typescript
+public readonly authorAddress: string;
+```
+
+- *Type:* string
+
+Email address for project author.
 
 ---
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -34,5 +34,6 @@
     "ts-jest",
     "@types/babel__traverse",
     "@types/prettier"
-  ]
+  ],
+  "rangeStrategy": "bump"
 }

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -10,7 +10,7 @@ export module clickupTs {
 
   export const devDeps = ['esbuild', 'eslint-config-prettier', 'eslint-plugin-prettier', 'jsii-release', 'prettier'];
 
-  export const defaults = {
+  export const defaults: Partial<ClickUpTypeScriptProjectOptions> = {
     authorAddress: 'devops@clickup.com',
     authorName: 'ClickUp',
     authorOrganization: true,
@@ -30,6 +30,9 @@ export module clickupTs {
     renovatebotOptions: {
       scheduleInterval: ['before 1am on Monday'],
       ignoreProjen: false,
+      overrideConfig: {
+        rangeStrategy: 'bump'
+      }
     },
 
     workflowBootstrapSteps: [
@@ -177,6 +180,11 @@ export module clickupTs {
      * NOTE: `docgen` attribute cannot be false.
      */
     readonly docgenOptions?: TypedocDocgenOptions;
+
+    /**
+     * Email address for project author
+     */
+    readonly authorAddress?: string;
   }
 
   /**

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -31,8 +31,8 @@ export module clickupTs {
       scheduleInterval: ['before 1am on Monday'],
       ignoreProjen: false,
       overrideConfig: {
-        rangeStrategy: 'bump'
-      }
+        rangeStrategy: 'bump',
+      },
     },
 
     workflowBootstrapSteps: [


### PR DESCRIPTION
The renovate dashboard isn't listing the ecs fargate dependency due to the default behaviour of renovate to only update packages which don't match the semver range in the package.json:

> For example, if your package.json specifies a value for left-pad of ^1.0.0 and the latest version on npmjs is 1.2.0, then Renovate won't change anything because 1.2.0 satisfies the range. If instead you'd prefer to be updated to ^1.2.0 in cases like this, then configure rangeStrategy to bump in your Renovate config.

![CleanShot 2023-01-10 at 11 34 53](https://user-images.githubusercontent.com/6425649/211541806-415797f8-22f6-4daa-9962-d9c0566e917c.png)

So we fix this by setting the `rangeStrategy` to `bump` to get the behaviour we want which most closely mimics projen's default package upgrade behaviour and will allow us not to waste time making manual update PRs
