### PR TITLE
fix(renovate): disable version pinning renovate preset

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -68,6 +68,7 @@ const project = new cdk.JsiiProject({
     ignoreProjen: false,
     overrideConfig: {
       rangeStrategy: 'bump',
+      extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],
     },
   },
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,6 @@
     "before 1am on Monday"
   ],
   "extends": [
-    ":preserveSemverRanges",
     "config:base",
     "group:allNonMajor",
     "group:recommended",

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -32,6 +32,7 @@ export module clickupTs {
       ignoreProjen: false,
       overrideConfig: {
         rangeStrategy: 'bump',
+        extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],
       },
     },
 


### PR DESCRIPTION
Take 2 at fixing upgrading all deps by removing the `:preserveSemverRanges` preset.