### PR TITLE
fix(renovate): ignore node from renovate updates

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -66,6 +66,10 @@ const project = new cdk.JsiiProject({
   renovatebotOptions: {
     scheduleInterval: ['before 1am on Monday'],
     ignoreProjen: false,
+    ignore: [
+      // managed by projen
+      'node',
+    ],
     overrideConfig: {
       rangeStrategy: 'bump',
       extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,7 +32,8 @@
     "standard-version",
     "ts-jest",
     "@types/babel__traverse",
-    "@types/prettier"
+    "@types/prettier",
+    "node"
   ],
   "rangeStrategy": "bump"
 }

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -30,6 +30,10 @@ export module clickupTs {
     renovatebotOptions: {
       scheduleInterval: ['before 1am on Monday'],
       ignoreProjen: false,
+      ignore: [
+        // managed by projen
+        'node',
+      ],
       overrideConfig: {
         rangeStrategy: 'bump',
         extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],


### PR DESCRIPTION
Prevents renovate trying to update the node version in the package.json as this is handled by projen:

![CleanShot 2023-01-10 at 19 34 14](https://user-images.githubusercontent.com/6425649/211644924-57ef89d8-7aa5-4ead-b97f-30ed90dacac5.png)
