### PR TITLE
chore(renovate): rename and fix upgrade trigger script

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,9 @@ projen new --from /Users/ahammond/Documents/ClickUp/clickup-projen/dist/js/click
 
 ## Upgrading Dependencies...Quickly
 
-NOTE: we need to update this to work in a `renovate` world.
-
 Since there will be many repos which are created as `clickup-projen` based projects, there will be many which utilize the same common dependencies. Even beyond that, sometimes waiting for the dependabot functionality takes too long depending on the frequency at which it's set to run.
 
-Sometimes, we need to push out a dependency to all consuming repos _fast_. Rather than iterating manually through each GitHub repository and executing the `upgrade-main` GitHub Workflow, we can run the `triggerUpgradeMain.sh` script at the root of the repo to trigger a dependency upgrade (via PR) for each repo with a given suffix.
+Sometimes, we need to push out a dependency to all consuming repos _fast_. Rather than iterating manually through each GitHub repository and executing the `upgrade-main` GitHub Workflow, we can run the `triggerRenovate.sh` script at the root of the repo to trigger a dependency upgrade (via PR) for each repo with a given suffix.
 
 ### Requirements
 
@@ -263,5 +261,5 @@ The following are optional variables with defaults:
 Here is an example:
 
 ```bash
-> REPO_OWNER='time-loop' REPO_SUFFIX='-cdk' ./triggerUpgradeMain.sh
+> REPO_OWNER='time-loop' REPO_SUFFIX='-cdk' ./triggerRenovate.sh
 ```

--- a/triggerRenovate.sh
+++ b/triggerRenovate.sh
@@ -16,22 +16,22 @@ function testGhCli() {
 }
 
 # Finds all repos with a given suffix under REPO_OWNER org, then iterates over
-# them triggering an `upgrade-main` workflow for each. 
+# them triggering a `renovate` workflow for each.
 function runUpgradeMain() {
     local owner="${REPO_OWNER}";
     local repos=($(gh repo list "${owner}" --limit "${REPO_LIMIT}" --no-archived --json name -q ".[].name | select(endswith(\"${REPO_SUFFIX}\"))"));
     RC=0; # return code counts total number of failures
     for repo in ${repos[@]}; do
-        echo "Triggering upgrade-main workflow on repo ${repo}";
-        if gh workflow run --repo "${owner}/${repo}" --ref main upgrade-main; then
+        echo "Triggering renovate workflow on repo ${repo}";
+        if gh workflow run --repo "${owner}/${repo}" --ref main renovate.yml; then
             sleep 2; # Give GitHub enough time to register the workflow_dispatch event
             echo 'Verifying workflow_dispatch event was actually created...';
-            local runningCount=$(gh run list --repo "${owner}/${repo}" --workflow=upgrade-main.yml --json 'name,status' -q '.[0] | select((.status=="in_progress") or (.status=="queued"))' | wc -l);
-            test "${runningCount}" -eq 0 && echo -e "${RED}Could not find trigger for upgrade-main workflow on repo ${repo}.${NC}\n" && RC=$(($RC + 1)) \
+            local runningCount=$(gh run list --repo "${owner}/${repo}" --workflow=renovate.yml --json 'name,status' -q '.[0] | select((.status=="in_progress") or (.status=="queued"))' | wc -l);
+            test "${runningCount}" -eq 0 && echo -e "${RED}Could not find trigger for renovate workflow on repo ${repo}.${NC}\n" && RC=$(($RC + 1)) \
                 || echo -e "${GREEN}Trigger succeeded. Continuing...${NC}\n";
         else
             RC=$(($RC + 1));
-            echo -e "${RED}Trigger for upgrade-main workflow on repo ${repo} failed.${NC}\n";
+            echo -e "${RED}Trigger for renovate workflow on repo ${repo} failed.${NC}\n";
         fi
     done
     echo -e "\nTotal failure count is: ${RC}";


### PR DESCRIPTION
Fixes upgrade main script after the move to renovate. Tested and it works great:

```
mattlewis@Matts-MacBook-Pro-2 clickup-projen % REPO_SUFFIX='stage1-cdk' ./triggerRenovate.sh
Verified gh CLI tool is accessible.
Triggering renovate workflow on repo stage1-cdk
✓ Created workflow_dispatch event for renovate.yml at main

To see runs for this workflow, try: gh run list --workflow=renovate.yml
Verifying workflow_dispatch event was actually created...
Trigger succeeded. Continuing...


Total failure count is: 0
```

Triggered:
![CleanShot 2023-01-12 at 12 42 11](https://user-images.githubusercontent.com/6425649/212069249-43f0fca5-e82e-4a3f-b43c-a735ecbb9ac9.png)
