### PR TITLE
fix(datadog): migrate away from deprecated github action syntax for setting outputs

### DIFF
--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -91,7 +91,7 @@ export module datadog {
           {
             name: 'Get version',
             id: 'event_metadata',
-            run: `echo ::set-output name=release_tag::"$(cat ${project.release!.artifactsDirectory}/releasetag.txt)"`,
+            run: `echo "release_tag=$(cat ${project.release!.artifactsDirectory}/releasetag.txt)" >> $GITHUB_OUTPUT`,
           },
           {
             name: 'Send Datadog event',

--- a/test/__snapshots__/datadog.test.ts.snap
+++ b/test/__snapshots__/datadog.test.ts.snap
@@ -86,7 +86,7 @@ jobs:
           path: dist
       - name: Get version
         id: event_metadata
-        run: echo ::set-output name=release_tag::\\"$(cat dist/releasetag.txt)\\"
+        run: echo \\"release_tag=$(cat dist/releasetag.txt)\\" >> $GITHUB_OUTPUT
       - name: Send Datadog event
         uses: Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948
         with:
@@ -185,7 +185,7 @@ jobs:
           path: dist
       - name: Get version
         id: event_metadata
-        run: echo ::set-output name=release_tag::\\"$(cat dist/releasetag.txt)\\"
+        run: echo \\"release_tag=$(cat dist/releasetag.txt)\\" >> $GITHUB_OUTPUT
       - name: Send Datadog event
         uses: Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948
         with:
@@ -284,7 +284,7 @@ jobs:
           path: dist
       - name: Get version
         id: event_metadata
-        run: echo ::set-output name=release_tag::\\"$(cat dist/releasetag.txt)\\"
+        run: echo \\"release_tag=$(cat dist/releasetag.txt)\\" >> $GITHUB_OUTPUT
       - name: Send Datadog event
         uses: Glennmen/datadog-event-action@fb18624879901f1ff0c3c7e1e102179793bfe948
         with:


### PR DESCRIPTION
On 1st June this will break the world: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/