### PR TITLE
fix(renovate): run renovate when a user ticks the rebase now option on a PR

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,6 +14,9 @@ on:
   issues:
     types:
       - edited
+  pull_request:
+    types:
+      - edited
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.event_name || '' }}
 jobs:
@@ -26,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v34.56.3
-        if: github.event_name != 'issues' || github.actor != 'cu-infra-svc-git'
+        if: (github.event_name != 'issues' && github.event_name != 'pull_request') || github.actor != 'cu-infra-svc-git'
         with:
           configurationFile: renovate.json5
           token: x-access-token:${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/src/renovate-workflow.ts
+++ b/src/renovate-workflow.ts
@@ -16,8 +16,12 @@ export module renovateWorkflow {
         branches: ['main'],
         paths: ['renovate.json5', '.github/workflows/renovate.yml'],
       },
-      // Run immediately when a box to update a dependency is checked on the renovate dashboard
+      // Run immediately when a box to update a dependency is checked on the renovate dashboard issue
       issues: {
+        types: ['edited'],
+      },
+      // or when the rebase now checkbox is ticked on a renovate PR description
+      pull_request: {
         types: ['edited'],
       },
     },
@@ -40,7 +44,7 @@ export module renovateWorkflow {
             name: 'Self-hosted Renovate',
             uses: 'renovatebot/github-action@v34.56.3',
             // Skip running renovate in a loop when renovate updates the dependency dashboard issue and re-triggers this workflow
-            if: "github.event_name != 'issues' || github.actor != 'cu-infra-svc-git'",
+            if: "(github.event_name != 'issues' && github.event_name != 'pull_request') || github.actor != 'cu-infra-svc-git'",
             with: {
               // projen creates this config for us
               configurationFile: 'renovate.json5',

--- a/test/__snapshots__/renovate-workflow.test.ts.snap
+++ b/test/__snapshots__/renovate-workflow.test.ts.snap
@@ -17,6 +17,9 @@ on:
   issues:
     types:
       - edited
+  pull_request:
+    types:
+      - edited
 concurrency:
   group: \${{ github.workflow }}-\${{ github.event_name == 'workflow_dispatch' && github.event_name || '' }}
 jobs:
@@ -29,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v34.56.3
-        if: github.event_name != 'issues' || github.actor != 'cu-infra-svc-git'
+        if: (github.event_name != 'issues' && github.event_name != 'pull_request') || github.actor != 'cu-infra-svc-git'
         with:
           configurationFile: renovate.json5
           token: x-access-token:\${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -59,6 +62,9 @@ on:
   issues:
     types:
       - edited
+  pull_request:
+    types:
+      - edited
 concurrency:
   group: \${{ github.workflow }}-\${{ github.event_name == 'workflow_dispatch' && github.event_name || '' }}
 jobs:
@@ -71,7 +77,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v34.56.3
-        if: github.event_name != 'issues' || github.actor != 'cu-infra-svc-git'
+        if: (github.event_name != 'issues' && github.event_name != 'pull_request') || github.actor != 'cu-infra-svc-git'
         with:
           configurationFile: renovate.json5
           token: x-access-token:\${{ secrets.PROJEN_GITHUB_TOKEN }}


### PR DESCRIPTION
Solves this problem by running renovate when the rebase checkbox is ticked on a pull request:
<img width="1344" alt="CleanShot 2023-01-19 at 13 21 32@2x" src="https://user-images.githubusercontent.com/6425649/213453480-3cd96c69-831e-4b86-bc05-07dff754df58.png">
