### PR TITLE
fix(renovate): make sure all weekly renovate PRs are created + produce less PRs

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -63,18 +63,7 @@ const project = new cdk.JsiiProject({
 
   depsUpgrade: false,
   renovatebot: true,
-  renovatebotOptions: {
-    scheduleInterval: ['before 1am on Monday'],
-    ignoreProjen: false,
-    ignore: [
-      // managed by projen
-      'node',
-    ],
-    overrideConfig: {
-      rangeStrategy: 'bump',
-      extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],
-    },
-  },
+  renovatebotOptions: renovateWorkflow.getRenovateOptions(),
 
   jestOptions: {
     jestConfig: {

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,18 +9,6 @@
     "group:recommended",
     "group:monorepos"
   ],
-  "packageRules": [
-    {
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "groupName": "devDependencies (non-major)"
-    }
-  ],
   "ignoreDeps": [
     "@types/jest",
     "@types/node",

--- a/renovate.json5
+++ b/renovate.json5
@@ -35,5 +35,7 @@
     "@types/prettier",
     "node"
   ],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0
 }

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -28,18 +28,7 @@ export module clickupTs {
       workflow: false,
     },
     renovatebot: true,
-    renovatebotOptions: {
-      scheduleInterval: ['before 1am on Monday'],
-      ignoreProjen: false,
-      ignore: [
-        // managed by projen
-        'node',
-      ],
-      overrideConfig: {
-        rangeStrategy: 'bump',
-        extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],
-      },
-    },
+    renovatebotOptions: renovateWorkflow.getRenovateOptions(),
     workflowBootstrapSteps: [
       {
         name: 'GitHub Packages authorization',

--- a/src/renovate-workflow.ts
+++ b/src/renovate-workflow.ts
@@ -86,6 +86,8 @@ export module renovateWorkflow {
           /* override projen renovate defaults */
           // Remove :preserveSemverRanges preset added by projen to make renovate update all non breaking dependencies
           extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],
+          // Disable projen default of separating dependencies from devDependencies, this just creates more PRs than necessary
+          packageRules: undefined,
 
           /* override defaults set in config:base preset */
           // update all dependencies, not just major versions

--- a/src/renovate-workflow.ts
+++ b/src/renovate-workflow.ts
@@ -80,12 +80,21 @@ export module renovateWorkflow {
         scheduleInterval: ['before 1am on Monday'],
         ignoreProjen: false,
         ignore: [
-          // managed by projen
-          'node',
+          'node', // managed by projen
         ],
         overrideConfig: {
-          rangeStrategy: 'bump',
+          /* override projen renovate defaults */
+          // Remove :preserveSemverRanges preset added by projen to make renovate update all non breaking dependencies
           extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],
+
+          /* override defaults set in config:base preset */
+          // update all dependencies, not just major versions
+          rangeStrategy: 'bump',
+          // Create PRs for all updates in one go as we only run renovate once a week
+          // as this option is designed for when renovate runs hourly
+          prHourlyLimit: 0,
+          // Have no limit on the number of renovate PRs open
+          prConcurrentLimit: 0,
         },
       },
       customOptions,

--- a/src/renovate-workflow.ts
+++ b/src/renovate-workflow.ts
@@ -1,4 +1,5 @@
-import { typescript, YamlFile } from 'projen';
+import { typescript, YamlFile, RenovatebotOptions } from 'projen';
+import merge from 'ts-deepmerge';
 
 export module renovateWorkflow {
   const defaultWorkflow = {
@@ -72,6 +73,24 @@ export module renovateWorkflow {
       },
     },
   };
+
+  export function getRenovateOptions(customOptions: Partial<RenovatebotOptions> = {}) {
+    return merge(
+      {
+        scheduleInterval: ['before 1am on Monday'],
+        ignoreProjen: false,
+        ignore: [
+          // managed by projen
+          'node',
+        ],
+        overrideConfig: {
+          rangeStrategy: 'bump',
+          extends: ['config:base', 'group:allNonMajor', 'group:recommended', 'group:monorepos'],
+        },
+      },
+      customOptions,
+    );
+  }
 
   export function addRenovateWorkflowYml(project: typescript.TypeScriptProject, override?: any): void {
     new YamlFile(project, '.github/workflows/renovate.yml', { obj: { ...defaultWorkflow, ...override } });

--- a/test/renovate-workflow.test.ts
+++ b/test/renovate-workflow.test.ts
@@ -22,3 +22,13 @@ describe('addRenovateWorkflowYml', () => {
     expect(synth['.github/workflows/renovate.yml']).toMatchSnapshot();
   });
 });
+
+describe('getRenovateOptions', () => {
+  test('merges options', () => {
+    const options = renovateWorkflow.getRenovateOptions({ overrideConfig: { dryRun: true } });
+    // custom option we set
+    expect(options.overrideConfig.dryRun).toBe(true);
+    // default option that should be deep merged in
+    expect(options.overrideConfig.rangeStrategy).toBe('bump');
+  });
+});


### PR DESCRIPTION
1. Refactors renovate config so it's shared in 1 place to make it easier to make updates while still letting us override defaults on a per usage basis if required

2. Fixes this rate limit problem caused by renovate only creating a maximum of 2 PRs per run 
<img width="788" alt="CleanShot 2023-02-01 at 14 29 29@2x" src="https://user-images.githubusercontent.com/6425649/216070672-e689e9b9-8a2d-4b69-800f-6897dc389ba7.png">

![image](https://user-images.githubusercontent.com/6425649/216070954-f8bcb5b6-af9d-4edf-b127-a110d98ce04b.png)


3. Produce less weekly update PRs by grouping these dependency and dev dependency update PRs together: 
<img width="712" alt="CleanShot 2023-02-01 at 14 28 08@2x" src="https://user-images.githubusercontent.com/6425649/216070374-92052c42-2bb3-4db4-ae0f-fecda0a285f5.png">
