### PR TITLE
fix(inbox): Fix issue where stack name was getting clobbered

### DIFF
--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -245,7 +245,7 @@ export module cdkDiffWorkflow {
   }
 
   export function AddCdkLogParserDependency(pkg: NodePackage) {
-    pkg.addDevDeps('@time-loop/cdk-log-parser@0.0.1');
+    pkg.addDevDeps('@time-loop/cdk-log-parser@0.0.4');
   }
 
   export function addOidcRoleStack(project: typescript.TypeScriptProject): void {

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -797,7 +797,7 @@ Object {
     "multi-convention-namer": "*",
   },
   "devDependencies": Object {
-    "@time-loop/cdk-log-parser": "0.0.1",
+    "@time-loop/cdk-log-parser": "0.0.4",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",


### PR DESCRIPTION
* Bumps `cdk-log-parser` dependency for `cdk-diff-workflow`
  
  * Context: Some cdk-diff runs have extra output and this caused issues with the older log parser versions. This was resolved in `0.0.4`
  
  * Example:
![CleanShot 2023-02-14 at 11 18 16](https://user-images.githubusercontent.com/94189859/218795656-8bb6cbd4-ec25-4cea-b91f-6acb4512168c.png)
