### PR TITLE
chore: Add log retention for cdk-diff workflow

### DIFF
--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -75,6 +75,15 @@ export module cdkDiffWorkflow {
                 'github-token': '${{ secrets.GITHUB_TOKEN }}',
               },
             },
+            {
+              name: 'Save processed diff logs',
+              uses: 'actions/upload-artifact@v3.1.2',
+              with: {
+                name: 'ProcessedDiffLogs',
+                path: '*.log',
+                'retention-days': 3,
+              },
+            },
           ],
         },
       },

--- a/test/__snapshots__/cdk-diff-workflow.test.ts.snap
+++ b/test/__snapshots__/cdk-diff-workflow.test.ts.snap
@@ -84,6 +84,12 @@ jobs:
         if: steps.should-auto-merge.outputs.auto-merge
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
+      - name: Save processed diff logs
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: ProcessedDiffLogs
+          path: \\"*.log\\"
+          retention-days: 3
 "
 `;
 
@@ -171,6 +177,12 @@ jobs:
         if: steps.should-auto-merge.outputs.auto-merge
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
+      - name: Save processed diff logs
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: ProcessedDiffLogs
+          path: \\"*.log\\"
+          retention-days: 3
 "
 `;
 
@@ -258,6 +270,12 @@ jobs:
         if: steps.should-auto-merge.outputs.auto-merge
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
+      - name: Save processed diff logs
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: ProcessedDiffLogs
+          path: \\"*.log\\"
+          retention-days: 3
 "
 `;
 
@@ -397,5 +415,11 @@ jobs:
         if: steps.should-auto-merge.outputs.auto-merge
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
+      - name: Save processed diff logs
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: ProcessedDiffLogs
+          path: \\"*.log\\"
+          retention-days: 3
 "
 `;


### PR DESCRIPTION
* Add log retention for the cdk-diff outputs to make troubleshooting simpler!