### PR TITLE
chore(deps): REVERT bump min node version to 14.21.3

### DIFF
--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -56,8 +56,8 @@ export module clickupTs {
     ],
     gitignore: ['/.npmrc', '.idea', '.yalc', 'yalc.lock'],
 
-    minNodeVersion: '14.21.3', // Required by eslint-import-resolver-typescript@3.3.0
-    workflowNodeVersion: '14.21.3',
+    minNodeVersion: '14.18.0', // Required by eslint-import-resolver-typescript@3.3.0
+    workflowNodeVersion: '14.18.0',
 
     prettier: true,
     prettierOptions: {

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -38,7 +38,7 @@ Object {
     "typescript": "*",
   },
   "engines": Object {
-    "node": ">= 14.21.3",
+    "node": ">= 14.18.0",
   },
   "jest": Object {
     "clearMocks": true,
@@ -181,7 +181,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.21.3
+          node-version: 14.18.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -214,7 +214,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.21.3
+          node-version: 14.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -244,7 +244,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.21.3
+          node-version: 14.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -370,7 +370,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.21.3
+          node-version: 14.18.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -403,7 +403,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.21.3
+          node-version: 14.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -516,7 +516,7 @@ Object {
     "typescript": "*",
   },
   "engines": Object {
-    "node": ">= 14.21.3",
+    "node": ">= 14.18.0",
   },
   "jest": Object {
     "clearMocks": true,
@@ -822,7 +822,7 @@ Object {
     "typescript": "*",
   },
   "engines": Object {
-    "node": ">= 14.21.3",
+    "node": ">= 14.18.0",
   },
   "jest": Object {
     "clearMocks": true,

--- a/test/__snapshots__/clickup-ts.test.ts.snap
+++ b/test/__snapshots__/clickup-ts.test.ts.snap
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.21.3
+          node-version: 14.18.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.21.3
+          node-version: 14.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.21.3
+          node-version: 14.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -244,7 +244,7 @@ Object {
     "typescript": "*",
   },
   "engines": Object {
-    "node": ">= 14.21.3",
+    "node": ">= 14.18.0",
   },
   "jest": Object {
     "clearMocks": true,


### PR DESCRIPTION
This reverts commit 693fe66e0b7f8b52236f6199065ae3c37845f0f4.

cdkPipeline's runner were failing with

```
[1/5] Validating package.json...
error clickup-ecs-cdk@0.0.0: The engine "node" is incompatible with this module. Expected version ">= 14.21.3". Got "14.19.3"
```