### PR TITLE
chore(deps): Bump cdk-diff-log parser and loose pin it!

### DIFF
--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -254,7 +254,7 @@ export module cdkDiffWorkflow {
   }
 
   export function AddCdkLogParserDependency(pkg: NodePackage) {
-    pkg.addDevDeps('@time-loop/cdk-log-parser@0.0.4');
+    pkg.addDevDeps('@time-loop/cdk-log-parser@~0.0.4');
   }
 
   export function addOidcRoleStack(project: typescript.TypeScriptProject): void {

--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -254,7 +254,7 @@ export module cdkDiffWorkflow {
   }
 
   export function AddCdkLogParserDependency(pkg: NodePackage) {
-    pkg.addDevDeps('@time-loop/cdk-log-parser@~0.0.4');
+    pkg.addDevDeps('@time-loop/cdk-log-parser@^0.0.4');
   }
 
   export function addOidcRoleStack(project: typescript.TypeScriptProject): void {

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -797,7 +797,7 @@ Object {
     "multi-convention-namer": "*",
   },
   "devDependencies": Object {
-    "@time-loop/cdk-log-parser": "~0.0.4",
+    "@time-loop/cdk-log-parser": "^0.0.4",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -797,7 +797,7 @@ Object {
     "multi-convention-namer": "*",
   },
   "devDependencies": Object {
-    "@time-loop/cdk-log-parser": "0.0.4",
+    "@time-loop/cdk-log-parser": "~0.0.4",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",


### PR DESCRIPTION
* Each new version of this lib should be adopted automatically without having to update this repo.
* Loose pinned it to accomplish this!
* Tested this locally with `yalc` and performs as expected