### PR TITLE
fix(deps): pin npm-check-updates to last version that supported node 14

### DIFF
--- a/src/clickup-cdk.ts
+++ b/src/clickup-cdk.ts
@@ -115,6 +115,7 @@ export module clickupCdk {
         }),
       );
       clickupTs.fixTsNodeDeps(this.package);
+      clickupTs.addResolutions(this.package);
       codecov.addCodeCovYml(this);
       nodeVersion.addNodeVersionFile(this);
       renovateWorkflow.addRenovateWorkflowYml(this);
@@ -157,6 +158,7 @@ export module clickupCdk {
         }),
       );
       clickupTs.fixTsNodeDeps(this.package);
+      clickupTs.addResolutions(this.package);
       new AppSampleCode(this);
       new SampleReadme(this, {
         contents: `[![codecov](https://codecov.io/gh/time-loop/WRITEME/branch/main/graph/badge.svg?token=WRITEME)](https://codecov.io/gh/time-loop/WRITEME)

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -229,6 +229,7 @@ export module clickupTs {
         }),
       );
       fixTsNodeDeps(this.package);
+      addResolutions(this.package);
       codecov.addCodeCovYml(this);
       nodeVersion.addNodeVersionFile(this);
       renovateWorkflow.addRenovateWorkflowYml(this);
@@ -249,5 +250,15 @@ export module clickupTs {
    */
   export function fixTsNodeDeps(pkg: NodePackage) {
     pkg.addDevDeps('ts-node@^10');
+  }
+
+  /**
+   * npm-check-updates dropped support for node 14 in a breaking change which breaks some of our node 14 CDK pipelines
+   * Until they fix the issue, we need to add a resolution to the package.json to force the use of an older version that supports node 14
+   * See https://github.com/raineorshine/npm-check-updates/issues/1300 for more info
+   * @param pkg
+   */
+  export function addResolutions(pkg: NodePackage) {
+    pkg.addPackageResolutions('npm-check-updates@16.10.8');
   }
 }

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -111,6 +111,7 @@ Object {
   "resolutions": Object {
     "@types/babel__traverse": "7.18.2",
     "@types/prettier": "2.6.0",
+    "npm-check-updates": "16.10.8",
   },
   "scripts": Object {
     "build": "npx projen build",
@@ -567,6 +568,9 @@ Object {
   "publishConfig": Object {
     "registry": "https://npm.pkg.github.com/",
   },
+  "resolutions": Object {
+    "npm-check-updates": "16.10.8",
+  },
   "scripts": Object {
     "build": "npx projen build",
     "bump": "npx projen bump",
@@ -872,6 +876,9 @@ Object {
   "name": "test",
   "publishConfig": Object {
     "registry": "https://npm.pkg.github.com/",
+  },
+  "resolutions": Object {
+    "npm-check-updates": "16.10.8",
   },
   "scripts": Object {
     "build": "npx projen build",

--- a/test/__snapshots__/clickup-ts.test.ts.snap
+++ b/test/__snapshots__/clickup-ts.test.ts.snap
@@ -295,6 +295,9 @@ Object {
   "publishConfig": Object {
     "registry": "https://npm.pkg.github.com/",
   },
+  "resolutions": Object {
+    "npm-check-updates": "16.10.8",
+  },
   "scripts": Object {
     "build": "npx projen build",
     "bump": "npx projen bump",


### PR DESCRIPTION
npm-check-updates dropped support for node 14 in a breaking change which [breaks some of our node 14 CDK pipelines](https://click-up.slack.com/archives/C03F94339PV/p1683585591180999)

Until that package fixes the issue, we need to add a resolution to the package.json to force the use of an older version that supports node 14

See https://github.com/raineorshine/npm-check-updates/issues/1300 for more info