### PR TITLE
fix(deps): unpin npm-check-updates now that node 14 support has been restored

### DIFF
--- a/src/clickup-cdk.ts
+++ b/src/clickup-cdk.ts
@@ -115,7 +115,6 @@ export module clickupCdk {
         }),
       );
       clickupTs.fixTsNodeDeps(this.package);
-      clickupTs.addResolutions(this.package);
       codecov.addCodeCovYml(this);
       nodeVersion.addNodeVersionFile(this);
       renovateWorkflow.addRenovateWorkflowYml(this);
@@ -158,7 +157,6 @@ export module clickupCdk {
         }),
       );
       clickupTs.fixTsNodeDeps(this.package);
-      clickupTs.addResolutions(this.package);
       new AppSampleCode(this);
       new SampleReadme(this, {
         contents: `[![codecov](https://codecov.io/gh/time-loop/WRITEME/branch/main/graph/badge.svg?token=WRITEME)](https://codecov.io/gh/time-loop/WRITEME)

--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -229,7 +229,6 @@ export module clickupTs {
         }),
       );
       fixTsNodeDeps(this.package);
-      addResolutions(this.package);
       codecov.addCodeCovYml(this);
       nodeVersion.addNodeVersionFile(this);
       renovateWorkflow.addRenovateWorkflowYml(this);
@@ -250,15 +249,5 @@ export module clickupTs {
    */
   export function fixTsNodeDeps(pkg: NodePackage) {
     pkg.addDevDeps('ts-node@^10');
-  }
-
-  /**
-   * npm-check-updates dropped support for node 14 in a breaking change which breaks some of our node 14 CDK pipelines
-   * Until they fix the issue, we need to add a resolution to the package.json to force the use of an older version that supports node 14
-   * See https://github.com/raineorshine/npm-check-updates/issues/1300 for more info
-   * @param pkg
-   */
-  export function addResolutions(pkg: NodePackage) {
-    pkg.addPackageResolutions('npm-check-updates@16.10.8');
   }
 }

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -111,7 +111,6 @@ Object {
   "resolutions": Object {
     "@types/babel__traverse": "7.18.2",
     "@types/prettier": "2.6.0",
-    "npm-check-updates": "16.10.8",
   },
   "scripts": Object {
     "build": "npx projen build",
@@ -568,9 +567,6 @@ Object {
   "publishConfig": Object {
     "registry": "https://npm.pkg.github.com/",
   },
-  "resolutions": Object {
-    "npm-check-updates": "16.10.8",
-  },
   "scripts": Object {
     "build": "npx projen build",
     "bump": "npx projen bump",
@@ -876,9 +872,6 @@ Object {
   "name": "test",
   "publishConfig": Object {
     "registry": "https://npm.pkg.github.com/",
-  },
-  "resolutions": Object {
-    "npm-check-updates": "16.10.8",
   },
   "scripts": Object {
     "build": "npx projen build",

--- a/test/__snapshots__/clickup-ts.test.ts.snap
+++ b/test/__snapshots__/clickup-ts.test.ts.snap
@@ -295,9 +295,6 @@ Object {
   "publishConfig": Object {
     "registry": "https://npm.pkg.github.com/",
   },
-  "resolutions": Object {
-    "npm-check-updates": "16.10.8",
-  },
   "scripts": Object {
     "build": "npx projen build",
     "bump": "npx projen bump",


### PR DESCRIPTION
Reverts time-loop/clickup-projen#158

This is no longer needed! https://github.com/raineorshine/npm-check-updates/issues/1300#issuecomment-1540664025