### PR TITLE
fix(cloud-platform): use env vars to our advantage [CLK-255341]

### DIFF
--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -48,11 +48,11 @@ export module clickupTs {
     workflowBootstrapSteps: [
       {
         name: 'GitHub Packages authorization',
-        // Conditional because of projen breakage: https://github.com/projen/projen/pull/2311
-        if: "${{ github.job != 'release_npm' }}",
+        // This does some env var obverloading where the release step also defines NPM_TOKEN with the action token that allows uploading
+        env: { NPM_TOKEN: '${{ secrets.ALL_PACKAGE_READ_TOKEN }}' },
         run: [
           'cat > .npmrc <<EOF',
-          '//npm.pkg.github.com/:_authToken=${{ secrets.ALL_PACKAGE_READ_TOKEN }}',
+          '//npm.pkg.github.com/:_authToken=${NPM_TOKEN}',
           '@time-loop:registry=https://npm.pkg.github.com/',
           'EOF',
         ].join('\n'),

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -170,10 +170,11 @@ jobs:
           git config user.name \\"github-actions\\"
           git config user.email \\"github-actions@github.com\\"
       - name: GitHub Packages authorization
-        if: \${{ github.job != 'release_npm' }}
+        env:
+          NPM_TOKEN: \${{ secrets.ALL_PACKAGE_READ_TOKEN }}
         run: |-
           cat > .npmrc <<EOF
-          //npm.pkg.github.com/:_authToken=\${{ secrets.ALL_PACKAGE_READ_TOKEN }}
+          //npm.pkg.github.com/:_authToken=\${NPM_TOKEN}
           @time-loop:registry=https://npm.pkg.github.com/
           EOF
       - name: Make cdk-ecr-deployment sane
@@ -254,10 +255,11 @@ jobs:
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
       - name: GitHub Packages authorization
-        if: \${{ github.job != 'release_npm' }}
+        env:
+          NPM_TOKEN: \${{ secrets.ALL_PACKAGE_READ_TOKEN }}
         run: |-
           cat > .npmrc <<EOF
-          //npm.pkg.github.com/:_authToken=\${{ secrets.ALL_PACKAGE_READ_TOKEN }}
+          //npm.pkg.github.com/:_authToken=\${NPM_TOKEN}
           @time-loop:registry=https://npm.pkg.github.com/
           EOF
       - name: Make cdk-ecr-deployment sane
@@ -359,10 +361,11 @@ jobs:
           git config user.name \\"github-actions\\"
           git config user.email \\"github-actions@github.com\\"
       - name: GitHub Packages authorization
-        if: \${{ github.job != 'release_npm' }}
+        env:
+          NPM_TOKEN: \${{ secrets.ALL_PACKAGE_READ_TOKEN }}
         run: |-
           cat > .npmrc <<EOF
-          //npm.pkg.github.com/:_authToken=\${{ secrets.ALL_PACKAGE_READ_TOKEN }}
+          //npm.pkg.github.com/:_authToken=\${NPM_TOKEN}
           @time-loop:registry=https://npm.pkg.github.com/
           EOF
       - name: Make cdk-ecr-deployment sane

--- a/test/__snapshots__/clickup-ts.test.ts.snap
+++ b/test/__snapshots__/clickup-ts.test.ts.snap
@@ -28,10 +28,11 @@ jobs:
           git config user.name \\"github-actions\\"
           git config user.email \\"github-actions@github.com\\"
       - name: GitHub Packages authorization
-        if: \${{ github.job != 'release_npm' }}
+        env:
+          NPM_TOKEN: \${{ secrets.ALL_PACKAGE_READ_TOKEN }}
         run: |-
           cat > .npmrc <<EOF
-          //npm.pkg.github.com/:_authToken=\${{ secrets.ALL_PACKAGE_READ_TOKEN }}
+          //npm.pkg.github.com/:_authToken=\${NPM_TOKEN}
           @time-loop:registry=https://npm.pkg.github.com/
           EOF
       - name: Make cdk-ecr-deployment sane


### PR DESCRIPTION
This does some magic to allow the package read token to be available for deps and still use the Github token when doing a package write during the Release step