### PR TITLE
fix(cloud-platform): suppress notices from cdk as they are invalid JSON

### DIFF
--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -104,9 +104,10 @@ export module cdkDiffWorkflow {
   function createStackCaptureStep(envsToDiff: (EnvToDiff | ExplicitStacksEnvToDiff)[]) {
     return {
       name: 'capture stacks to diff',
-      run: ['./node_modules/.bin/cdk ls -l -j > cdk-ls.json', ...createEnvVarsToCaptureStacksToDiff(envsToDiff)].join(
-        '\n',
-      ),
+      run: [
+        './node_modules/.bin/cdk ls -l -j --notices=false > cdk-ls.json',
+        ...createEnvVarsToCaptureStacksToDiff(envsToDiff),
+      ].join('\n'),
     };
   }
 

--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -175,7 +175,7 @@ export module cdkDiffWorkflow {
     return envsToDiff.map((env) => {
       return {
         name: `Apply '${env.labelToApplyWhenNoDiffPresent}' label based on diff status`,
-        if: `env.${env.name.toUpperCase()}_HAS_NO_DIFF === 'true'`,
+        if: `env.${env.name.toUpperCase()}_HAS_NO_DIFF == 'true'`,
         uses: 'actions/github-script@v6',
         with: {
           'github-token': '${{ secrets.GITHUB_TOKEN }}',
@@ -196,7 +196,7 @@ export module cdkDiffWorkflow {
     return envsToDiff.map((env) => {
       return {
         name: `Remove '${env.labelToApplyWhenNoDiffPresent}' label based on diff status given a previous commit may have had no diff but the current one does`,
-        if: `env.${env.name.toUpperCase()}_HAS_NO_DIFF !== 'true'`,
+        if: `env.${env.name.toUpperCase()}_HAS_NO_DIFF != 'true'`,
         uses: 'actions/github-script@v6',
         with: {
           'github-token': '${{ secrets.GITHUB_TOKEN }}',

--- a/test/__snapshots__/cdk-diff-workflow.test.ts.snap
+++ b/test/__snapshots__/cdk-diff-workflow.test.ts.snap
@@ -57,7 +57,7 @@ jobs:
           gunzip cdk-notifier.gz && chmod +x cdk-notifier && rm -rf cdk-notifier.gz
           ./cdk-notifier --log-file ./cdk-qa.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'qa Stacks - If truncated please see the action for the full log!'
       - name: Remove 'qa-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
-        if: env.QA_HAS_NO_DIFF !== 'true'
+        if: env.QA_HAS_NO_DIFF != 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
             })
             }
       - name: Apply 'qa-no-changes' label based on diff status
-        if: env.QA_HAS_NO_DIFF === 'true'
+        if: env.QA_HAS_NO_DIFF == 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
           gunzip cdk-notifier.gz && chmod +x cdk-notifier && rm -rf cdk-notifier.gz
           ./cdk-notifier --log-file ./cdk-qa.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'qa Stacks - If truncated please see the action for the full log!'
       - name: Remove 'qa-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
-        if: env.QA_HAS_NO_DIFF !== 'true'
+        if: env.QA_HAS_NO_DIFF != 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -192,7 +192,7 @@ jobs:
             })
             }
       - name: Apply 'qa-no-changes' label based on diff status
-        if: env.QA_HAS_NO_DIFF === 'true'
+        if: env.QA_HAS_NO_DIFF == 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -285,7 +285,7 @@ jobs:
           gunzip cdk-notifier.gz && chmod +x cdk-notifier && rm -rf cdk-notifier.gz
           ./cdk-notifier --log-file ./cdk-qa.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'qa Stacks - If truncated please see the action for the full log!'
       - name: Remove 'qa-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
-        if: env.QA_HAS_NO_DIFF !== 'true'
+        if: env.QA_HAS_NO_DIFF != 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -306,7 +306,7 @@ jobs:
             })
             }
       - name: Apply 'qa-no-changes' label based on diff status
-        if: env.QA_HAS_NO_DIFF === 'true'
+        if: env.QA_HAS_NO_DIFF == 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -427,7 +427,7 @@ jobs:
           ./cdk-notifier --log-file ./cdk-staging.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'staging Stacks - If truncated please see the action for the full log!'
           ./cdk-notifier --log-file ./cdk-prod.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'prod Stacks - If truncated please see the action for the full log!'
       - name: Remove 'qa-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
-        if: env.QA_HAS_NO_DIFF !== 'true'
+        if: env.QA_HAS_NO_DIFF != 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -448,7 +448,7 @@ jobs:
             })
             }
       - name: Remove 'staging-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
-        if: env.STAGING_HAS_NO_DIFF !== 'true'
+        if: env.STAGING_HAS_NO_DIFF != 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -469,7 +469,7 @@ jobs:
             })
             }
       - name: Remove 'prod-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
-        if: env.PROD_HAS_NO_DIFF !== 'true'
+        if: env.PROD_HAS_NO_DIFF != 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -490,7 +490,7 @@ jobs:
             })
             }
       - name: Apply 'qa-no-changes' label based on diff status
-        if: env.QA_HAS_NO_DIFF === 'true'
+        if: env.QA_HAS_NO_DIFF == 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -502,7 +502,7 @@ jobs:
             labels: [\\"qa-no-changes\\"]
             })
       - name: Apply 'staging-no-changes' label based on diff status
-        if: env.STAGING_HAS_NO_DIFF === 'true'
+        if: env.STAGING_HAS_NO_DIFF == 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -514,7 +514,7 @@ jobs:
             labels: [\\"staging-no-changes\\"]
             })
       - name: Apply 'prod-no-changes' label based on diff status
-        if: env.PROD_HAS_NO_DIFF === 'true'
+        if: env.PROD_HAS_NO_DIFF == 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}

--- a/test/__snapshots__/cdk-diff-workflow.test.ts.snap
+++ b/test/__snapshots__/cdk-diff-workflow.test.ts.snap
@@ -37,7 +37,7 @@ jobs:
         run: yarn install --check-files
       - name: capture stacks to diff
         run: |-
-          ./node_modules/.bin/cdk ls -l -j > cdk-ls.json
+          ./node_modules/.bin/cdk ls -l -j --notices=false > cdk-ls.json
           STACKS_TO_DIFF_QA=\\"UsQaSquadNameDynamoDBTableNameStack UsQaSquadNameS3BucketNameStack\\"
           echo \\"STACKS_TO_DIFF_QA=$STACKS_TO_DIFF_QA\\" >> $GITHUB_ENV
       - name: configure qa aws credentials
@@ -56,8 +56,29 @@ jobs:
           curl -L \\"https://github.com/karlderkaefer/cdk-notifier/releases/download/v2.3.2/cdk-notifier_$(uname)_amd64.gz\\" -o cdk-notifier.gz
           gunzip cdk-notifier.gz && chmod +x cdk-notifier && rm -rf cdk-notifier.gz
           ./cdk-notifier --log-file ./cdk-qa.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'qa Stacks - If truncated please see the action for the full log!'
+      - name: Remove 'qa-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
+        if: env.QA_HAS_NO_DIFF !== 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          script: |-
+            const labels = await github.paginate(
+            github.rest.issues.listLabelsOnIssue, {
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            }
+            )
+            if (labels.find(label => label.name === \\"qa-no-changes\\")) {
+            github.rest.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            name: \\"qa-no-changes\\"
+            })
+            }
       - name: Apply 'qa-no-changes' label based on diff status
-        if: env.QA_HAS_NO_DIFF == 'true'
+        if: env.QA_HAS_NO_DIFF === 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -130,7 +151,7 @@ jobs:
         run: yarn install --check-files
       - name: capture stacks to diff
         run: |-
-          ./node_modules/.bin/cdk ls -l -j > cdk-ls.json
+          ./node_modules/.bin/cdk ls -l -j --notices=false > cdk-ls.json
           STACKS_TO_DIFF_QA=\\"UsQaSquadNameDynamoDBTableNameStack\\"
           echo \\"STACKS_TO_DIFF_QA=$STACKS_TO_DIFF_QA\\" >> $GITHUB_ENV
       - name: configure qa aws credentials
@@ -149,8 +170,29 @@ jobs:
           curl -L \\"https://github.com/karlderkaefer/cdk-notifier/releases/download/v2.3.2/cdk-notifier_$(uname)_amd64.gz\\" -o cdk-notifier.gz
           gunzip cdk-notifier.gz && chmod +x cdk-notifier && rm -rf cdk-notifier.gz
           ./cdk-notifier --log-file ./cdk-qa.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'qa Stacks - If truncated please see the action for the full log!'
+      - name: Remove 'qa-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
+        if: env.QA_HAS_NO_DIFF !== 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          script: |-
+            const labels = await github.paginate(
+            github.rest.issues.listLabelsOnIssue, {
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            }
+            )
+            if (labels.find(label => label.name === \\"qa-no-changes\\")) {
+            github.rest.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            name: \\"qa-no-changes\\"
+            })
+            }
       - name: Apply 'qa-no-changes' label based on diff status
-        if: env.QA_HAS_NO_DIFF == 'true'
+        if: env.QA_HAS_NO_DIFF === 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -223,7 +265,7 @@ jobs:
         run: yarn install --check-files
       - name: capture stacks to diff
         run: |-
-          ./node_modules/.bin/cdk ls -l -j > cdk-ls.json
+          ./node_modules/.bin/cdk ls -l -j --notices=false > cdk-ls.json
           STACKS_TO_DIFF_QA=$(jq -r '[.[].id | select(contains(\\"Qa\\")) ] | join(\\" \\")' cdk-ls.json)
           echo \\"STACKS_TO_DIFF_QA=$STACKS_TO_DIFF_QA\\" >> $GITHUB_ENV
       - name: configure qa aws credentials
@@ -242,8 +284,29 @@ jobs:
           curl -L \\"https://github.com/karlderkaefer/cdk-notifier/releases/download/v2.3.2/cdk-notifier_$(uname)_amd64.gz\\" -o cdk-notifier.gz
           gunzip cdk-notifier.gz && chmod +x cdk-notifier && rm -rf cdk-notifier.gz
           ./cdk-notifier --log-file ./cdk-qa.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'qa Stacks - If truncated please see the action for the full log!'
+      - name: Remove 'qa-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
+        if: env.QA_HAS_NO_DIFF !== 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          script: |-
+            const labels = await github.paginate(
+            github.rest.issues.listLabelsOnIssue, {
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            }
+            )
+            if (labels.find(label => label.name === \\"qa-no-changes\\")) {
+            github.rest.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            name: \\"qa-no-changes\\"
+            })
+            }
       - name: Apply 'qa-no-changes' label based on diff status
-        if: env.QA_HAS_NO_DIFF == 'true'
+        if: env.QA_HAS_NO_DIFF === 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -316,7 +379,7 @@ jobs:
         run: yarn install --check-files
       - name: capture stacks to diff
         run: |-
-          ./node_modules/.bin/cdk ls -l -j > cdk-ls.json
+          ./node_modules/.bin/cdk ls -l -j --notices=false > cdk-ls.json
           STACKS_TO_DIFF_QA=$(jq -r '[.[].id | select(contains(\\"Qa\\")) ] | join(\\" \\")' cdk-ls.json)
           echo \\"STACKS_TO_DIFF_QA=$STACKS_TO_DIFF_QA\\" >> $GITHUB_ENV
           STACKS_TO_DIFF_STAGING=$(jq -r '[.[].id | select(contains(\\"Staging\\")) ] | join(\\" \\")' cdk-ls.json)
@@ -363,8 +426,71 @@ jobs:
           ./cdk-notifier --log-file ./cdk-qa.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'qa Stacks - If truncated please see the action for the full log!'
           ./cdk-notifier --log-file ./cdk-staging.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'staging Stacks - If truncated please see the action for the full log!'
           ./cdk-notifier --log-file ./cdk-prod.log --repo $REPO_NAME --owner $GITHUB_REPOSITORY_OWNER --token \${{ secrets.GITHUB_TOKEN }} --pull-request-id \${{ github.event.pull_request.number }} -t 'prod Stacks - If truncated please see the action for the full log!'
+      - name: Remove 'qa-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
+        if: env.QA_HAS_NO_DIFF !== 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          script: |-
+            const labels = await github.paginate(
+            github.rest.issues.listLabelsOnIssue, {
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            }
+            )
+            if (labels.find(label => label.name === \\"qa-no-changes\\")) {
+            github.rest.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            name: \\"qa-no-changes\\"
+            })
+            }
+      - name: Remove 'staging-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
+        if: env.STAGING_HAS_NO_DIFF !== 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          script: |-
+            const labels = await github.paginate(
+            github.rest.issues.listLabelsOnIssue, {
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            }
+            )
+            if (labels.find(label => label.name === \\"staging-no-changes\\")) {
+            github.rest.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            name: \\"staging-no-changes\\"
+            })
+            }
+      - name: Remove 'prod-no-changes' label based on diff status given a previous commit may have had no diff but the current one does
+        if: env.PROD_HAS_NO_DIFF !== 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          script: |-
+            const labels = await github.paginate(
+            github.rest.issues.listLabelsOnIssue, {
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            }
+            )
+            if (labels.find(label => label.name === \\"prod-no-changes\\")) {
+            github.rest.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            name: \\"prod-no-changes\\"
+            })
+            }
       - name: Apply 'qa-no-changes' label based on diff status
-        if: env.QA_HAS_NO_DIFF == 'true'
+        if: env.QA_HAS_NO_DIFF === 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -376,7 +502,7 @@ jobs:
             labels: [\\"qa-no-changes\\"]
             })
       - name: Apply 'staging-no-changes' label based on diff status
-        if: env.STAGING_HAS_NO_DIFF == 'true'
+        if: env.STAGING_HAS_NO_DIFF === 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
@@ -388,7 +514,7 @@ jobs:
             labels: [\\"staging-no-changes\\"]
             })
       - name: Apply 'prod-no-changes' label based on diff status
-        if: env.PROD_HAS_NO_DIFF == 'true'
+        if: env.PROD_HAS_NO_DIFF === 'true'
         uses: actions/github-script@v6
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -798,7 +798,7 @@ Object {
     "multi-convention-namer": "*",
   },
   "devDependencies": Object {
-    "@time-loop/cdk-log-parser": "^0.0.4",
+    "@time-loop/cdk-log-parser": "latest",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",


### PR DESCRIPTION
* The output of `cdk ls -j` should be pure and have no extra output so it can be consumed by `jq`
	* Unfortunately, cdk adds in notices when things are out of date
	* Added the `--notices=false` flag to prevent the extra output from causing JSON parsing errors

* While the `env-no-changes` labels don't control the auto merging, they can be confusing to reviewers if there are both cdk diff comments and `env-no-changes` labels
	* This happens when any commit has no changes, the labels get added
	* Then a subsequent commit introduces changes but the labels never get removed
	* Added a step per env to remove labels if present when a diff exists for that env
	* Can see this in action below!
	
![CleanShot 2023-05-31 at 22 12 54](https://github.com/time-loop/clickup-projen/assets/94189859/2e890c92-9e9d-4147-8df3-7b46f6f8df2a)


* Updated cdk-log-parser to always use the latest version to avoid needing to update this repo every time a small update occurs there/faster delivery to consumers.