### PR TITLE
chore(devops): fixing use of typedoc-plugin-markdown plugin [CLK-324594]

### DIFF
--- a/src/clickup-ts.ts
+++ b/src/clickup-ts.ts
@@ -159,6 +159,7 @@ export module clickupTs {
         entryPoints: ['./src/index.ts'],
         out: project.docsDirectory,
         readme: 'none',
+        plugin: props.html ? [] : ['typedoc-plugin-markdown'],
       };
       return new JsonFile(project, props.configFilePath ?? 'typedoc.json', {
         obj: {


### PR DESCRIPTION
# Summary

**Related task**: [CLK-324594](https://staging.clickup.com/t/333/CLK-324594)

- Fixing the use of `typedoc-plugin-markdown`

The `typedoc.json` file required the plugin configuration section to allow the creation of the documentation using the `typedoc-plugin-markdown`

### Example test with yalc
![image](https://github.com/time-loop/clickup-projen/assets/116575075/daaaa00a-3866-4c2b-a5a8-3cabcafd0b93)
