### PR TITLE
chore(devops): fixing schema-version parameter for dd service catalog [CLK-346825]

### DIFF
--- a/src/datadog-service-catalog.ts
+++ b/src/datadog-service-catalog.ts
@@ -185,7 +185,7 @@ export module datadogServiceCatalog {
         name: `Publish DD Service Catalog for ${serviceName}`,
         uses: 'arcxp/datadog-service-catalog-metadata-provider@v2',
         with: {
-          'service-version': `${DefaultServiceCatalogValues.SERVICE_VERSION}`,
+          'schema-version': `${DefaultServiceCatalogValues.SERVICE_VERSION}`,
           'datadog-hostname': `${DefaultServiceCatalogValues.DATADOG_HOSTNAME}`,
           'datadog-key': `${DefaultServiceCatalogValues.DATADOG_KEY}`,
           'datadog-app-key': `${DefaultServiceCatalogValues.DATADOG_APP_KEY}`,

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -1391,7 +1391,7 @@ jobs:
       - name: Publish DD Service Catalog for test-service
         uses: arcxp/datadog-service-catalog-metadata-provider@v2
         with:
-          service-version: "2.1"
+          schema-version: "2.1"
           datadog-hostname: app.datadoghq.com
           datadog-key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
           datadog-app-key: \${{ secrets.DD_PROJEN_RELEASE_APP_KEY }}
@@ -1573,7 +1573,7 @@ jobs:
       - name: Publish DD Service Catalog for test-service
         uses: arcxp/datadog-service-catalog-metadata-provider@v2
         with:
-          service-version: "2.1"
+          schema-version: "2.1"
           datadog-hostname: app.datadoghq.com
           datadog-key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
           datadog-app-key: \${{ secrets.DD_PROJEN_RELEASE_APP_KEY }}
@@ -1759,7 +1759,7 @@ jobs:
       - name: Publish DD Service Catalog for test-service
         uses: arcxp/datadog-service-catalog-metadata-provider@v2
         with:
-          service-version: "2.1"
+          schema-version: "2.1"
           datadog-hostname: app.datadoghq.com
           datadog-key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
           datadog-app-key: \${{ secrets.DD_PROJEN_RELEASE_APP_KEY }}
@@ -1949,7 +1949,7 @@ jobs:
       - name: Publish DD Service Catalog for test
         uses: arcxp/datadog-service-catalog-metadata-provider@v2
         with:
-          service-version: "2.1"
+          schema-version: "2.1"
           datadog-hostname: app.datadoghq.com
           datadog-key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
           datadog-app-key: \${{ secrets.DD_PROJEN_RELEASE_APP_KEY }}

--- a/test/__snapshots__/datadog-service-catalog.test.ts.snap
+++ b/test/__snapshots__/datadog-service-catalog.test.ts.snap
@@ -88,7 +88,7 @@ jobs:
       - name: Publish DD Service Catalog for test-service
         uses: arcxp/datadog-service-catalog-metadata-provider@v2
         with:
-          service-version: "2.1"
+          schema-version: "2.1"
           datadog-hostname: app.datadoghq.com
           datadog-key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
           datadog-app-key: \${{ secrets.DD_PROJEN_RELEASE_APP_KEY }}
@@ -212,7 +212,7 @@ jobs:
       - name: Publish DD Service Catalog for test-service
         uses: arcxp/datadog-service-catalog-metadata-provider@v2
         with:
-          service-version: "2.1"
+          schema-version: "2.1"
           datadog-hostname: app.datadoghq.com
           datadog-key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
           datadog-app-key: \${{ secrets.DD_PROJEN_RELEASE_APP_KEY }}
@@ -235,7 +235,7 @@ jobs:
       - name: Publish DD Service Catalog for test-cdk
         uses: arcxp/datadog-service-catalog-metadata-provider@v2
         with:
-          service-version: "2.1"
+          schema-version: "2.1"
           datadog-hostname: app.datadoghq.com
           datadog-key: \${{ secrets.DD_PROJEN_RELEASE_API_KEY }}
           datadog-app-key: \${{ secrets.DD_PROJEN_RELEASE_APP_KEY }}


### PR DESCRIPTION
# Summary
fixing schema-version parameter for dd service catalog
**Related task** [CLK-346825](https://staging.clickup.com/t/333/CLK-346825)
**Related documentation** [here](https://github.com/marketplace/actions/datadog-service-catalog-metadata-provider#schema-fields)
