### PR TITLE
feat(cdk): force source-map to ^0.7.4 [CLK-393642]

### DIFF
--- a/src/clickup-cdk.ts
+++ b/src/clickup-cdk.ts
@@ -20,6 +20,7 @@ export module clickupCdk {
     ...clickupTs.deps,
     '@time-loop/cdk-library',
     '@time-loop/cdk-named-environments',
+    'source-map@^0.7.4', // CLK-393642 and https://github.com/mozilla/source-map/issues/454
     'cdk-constants',
     'multi-convention-namer',
   ];

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -493,6 +493,7 @@ exports[`ClickUpCdkTypeScriptApp defaults package.json 1`] = `
     "cdk-constants": "*",
     "constructs": "^10.0.5",
     "multi-convention-namer": "*",
+    "source-map": "^0.7.4",
   },
   "devDependencies": {
     "@types/jest": "*",
@@ -944,6 +945,7 @@ exports[`ClickUpCdkTypeScriptApp options node20 package.json 1`] = `
     "cdk-constants": "*",
     "constructs": "^10.0.5",
     "multi-convention-namer": "*",
+    "source-map": "^0.7.4",
   },
   "devDependencies": {
     "@types/jest": "*",
@@ -1067,6 +1069,7 @@ exports[`cdk-diff additions - ClickUpCdkTypeScriptApp package.json 1`] = `
     "cdk-constants": "*",
     "constructs": "^10.0.5",
     "multi-convention-namer": "*",
+    "source-map": "^0.7.4",
   },
   "devDependencies": {
     "@time-loop/cdk-log-parser": "latest",


### PR DESCRIPTION
Per https://github.com/mozilla/source-map/issues/454 "This is fixed in [source-map@0.7.4](https://www.npmjs.com/package/source-map/v/0.7.4)."

Symptom:

```
Error: You must provide the URL of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer
    at readWasm (/home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/v8-to-istanbul/node_modules/source-map/lib/read-wasm.js:8:13)
    at wasm (/home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/v8-to-istanbul/node_modules/source-map/lib/wasm.js:25:16)
    at /home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/v8-to-istanbul/node_modules/source-map/lib/source-map-consumer.js:264:14
    at V8ToIstanbul.load (/home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/v8-to-istanbul/lib/v8-to-istanbul.js:65:26)
    at /home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/@jest/reporters/build/CoverageReporter.js:626:11
    at async Promise.all (index 0)
    at CoverageReporter._getCoverageResult (/home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/@jest/reporters/build/CoverageReporter.js:584:35)
    at CoverageReporter.onRunComplete (/home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/@jest/reporters/build/CoverageReporter.js:232:34)
    at ReporterDispatcher.onRunComplete (/home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/@jest/core/build/ReporterDispatcher.js:87:9)
    at TestScheduler.scheduleTests (/home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk/node_modules/@jest/core/build/TestScheduler.js:362:5)
👾 Task "build » test" failed when executing "jest --passWithNoTests --coverageProvider=v8 --updateSnapshot" (cwd: /home/runner/work/infratest-aurora-cdk/infratest-aurora-cdk)
Error: Process completed with exit code 1.
```