### PR TITLE
fix(alerts): upgrade download-artifact action to v4 [CLK-483275]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist

--- a/src/datadog-service-catalog.ts
+++ b/src/datadog-service-catalog.ts
@@ -132,7 +132,7 @@ export module datadogServiceCatalog {
         steps: [
           {
             name: 'Download build artifacts',
-            uses: 'actions/download-artifact@v3',
+            uses: 'actions/download-artifact@v4',
             with: {
               name: 'build-artifact',
               path: project.release!.artifactsDirectory,

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -85,7 +85,7 @@ export module datadog {
         steps: [
           {
             name: 'Download build artifacts',
-            uses: 'actions/download-artifact@v3',
+            uses: 'actions/download-artifact@v4',
             with: {
               name: 'build-artifact',
               path: project.release!.artifactsDirectory,

--- a/src/slack-alert.ts
+++ b/src/slack-alert.ts
@@ -59,7 +59,7 @@ export module slackAlert {
         steps: [
           {
             name: 'Download build artifacts',
-            uses: 'actions/download-artifact@v3',
+            uses: 'actions/download-artifact@v4',
             with: {
               name: 'build-artifact',
               path: project.release!.artifactsDirectory,

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -299,7 +299,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -324,7 +324,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -452,7 +452,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -477,7 +477,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -914,7 +914,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -939,7 +939,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1374,7 +1374,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1399,7 +1399,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1424,7 +1424,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1565,7 +1565,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1590,7 +1590,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1615,7 +1615,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1760,7 +1760,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1785,7 +1785,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1810,7 +1810,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1959,7 +1959,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -1984,7 +1984,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -2009,7 +2009,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -2150,7 +2150,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -2175,7 +2175,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist

--- a/test/__snapshots__/clickup-ts.test.ts.snap
+++ b/test/__snapshots__/clickup-ts.test.ts.snap
@@ -133,7 +133,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist

--- a/test/__snapshots__/datadog-service-catalog.test.ts.snap
+++ b/test/__snapshots__/datadog-service-catalog.test.ts.snap
@@ -88,7 +88,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -221,7 +221,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist

--- a/test/__snapshots__/datadog.test.ts.snap
+++ b/test/__snapshots__/datadog.test.ts.snap
@@ -90,7 +90,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -199,7 +199,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -308,7 +308,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist

--- a/test/__snapshots__/slack-alert.test.ts.snap
+++ b/test/__snapshots__/slack-alert.test.ts.snap
@@ -88,7 +88,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist
@@ -195,7 +195,7 @@ jobs:
     if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifact
           path: dist


### PR DESCRIPTION
Fixes failing workflows due to the artifact being uploaded with v4 and the download action still uses v3 (which uses different APIs and fails as a result)

![CleanShot 2024-03-28 at 08 45 34](https://github.com/time-loop/clickup-projen/assets/6425649/28f887da-7ace-43f7-9e92-2bc8953547c3)
