### PR TITLE
feat(workflows): replace cdk-log-parser tag with semver notation [CLK-493280]

### DIFF
--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -300,7 +300,7 @@ export module cdkDiffWorkflow {
   }
 
   export function AddCdkLogParserDependency(pkg: NodePackage) {
-    pkg.addDevDeps('@time-loop/cdk-log-parser@latest');
+    pkg.addDevDeps('@time-loop/cdk-log-parser@^0.0.18');
   }
 
   export function addOidcRoleStack(project: clickupCdk.ClickUpCdkTypeScriptApp): void {

--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -300,7 +300,7 @@ export module cdkDiffWorkflow {
   }
 
   export function AddCdkLogParserDependency(pkg: NodePackage) {
-    pkg.addDevDeps('@time-loop/cdk-log-parser@^0.0.18');
+    pkg.addDevDeps('@time-loop/cdk-log-parser');
   }
 
   export function addOidcRoleStack(project: clickupCdk.ClickUpCdkTypeScriptApp): void {

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -1102,7 +1102,7 @@ exports[`cdk-diff additions - ClickUpCdkTypeScriptApp package.json 1`] = `
     "source-map": "^0.7.4",
   },
   "devDependencies": {
-    "@time-loop/cdk-log-parser": "^0.0.18",
+    "@time-loop/cdk-log-parser": "*",
     "@types/jest": "*",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6",

--- a/test/__snapshots__/clickup-cdk.test.ts.snap
+++ b/test/__snapshots__/clickup-cdk.test.ts.snap
@@ -1102,7 +1102,7 @@ exports[`cdk-diff additions - ClickUpCdkTypeScriptApp package.json 1`] = `
     "source-map": "^0.7.4",
   },
   "devDependencies": {
-    "@time-loop/cdk-log-parser": "latest",
+    "@time-loop/cdk-log-parser": "^0.0.18",
     "@types/jest": "*",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6",


### PR DESCRIPTION
Removes `cdk-log-parser` module version so that each repo can manage the proper version for this module