### PR TITLE
feat(security): update semgrep to 1.78.0 [SEC-8536]

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,7 +12,7 @@ jobs:
     name: Scan
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep@sha256:d08d065e4041a222e7b54ed2ad8faddfef978bcc210aa9d0b6da93d251082808
+      image: semgrep/semgrep@sha256:aeb24a8f042cb60fc64a87c6e52b01033fb11442fd224ccc41cc363f5ca3aa10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/src/semgrep-workflow.ts
+++ b/src/semgrep-workflow.ts
@@ -19,7 +19,7 @@ export module semgrepWorkflow {
         'runs-on': 'ubuntu-latest',
         container: {
           // Reocurring task to check the pinned version SEC-8540
-          image: 'semgrep/semgrep@sha256:d08d065e4041a222e7b54ed2ad8faddfef978bcc210aa9d0b6da93d251082808',
+          image: 'semgrep/semgrep@sha256:aeb24a8f042cb60fc64a87c6e52b01033fb11442fd224ccc41cc363f5ca3aa10', // 1.78.0
         },
         steps: [
           {

--- a/test/__snapshots__/semgrep-workflow.test.ts.snap
+++ b/test/__snapshots__/semgrep-workflow.test.ts.snap
@@ -15,7 +15,7 @@ jobs:
     name: Scan
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep@sha256:d08d065e4041a222e7b54ed2ad8faddfef978bcc210aa9d0b6da93d251082808
+      image: semgrep/semgrep@sha256:aeb24a8f042cb60fc64a87c6e52b01033fb11442fd224ccc41cc363f5ca3aa10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
     name: Scan
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep@sha256:d08d065e4041a222e7b54ed2ad8faddfef978bcc210aa9d0b6da93d251082808
+      image: semgrep/semgrep@sha256:aeb24a8f042cb60fc64a87c6e52b01033fb11442fd224ccc41cc363f5ca3aa10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Updating semgrep docker image to [1.78.0](https://hub.docker.com/layers/semgrep/semgrep/1.78.0/images/sha256-aeb24a8f042cb60fc64a87c6e52b01033fb11442fd224ccc41cc363f5ca3aa10?context=explore)