### PR TITLE
fix(cloud-platform): update GH artifact actions to v4[INFRA-31035]

### DIFF
--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -100,7 +100,7 @@ export module cdkDiffWorkflow {
             },
             {
               name: 'Save processed diff logs',
-              uses: 'actions/upload-artifact@v3.1.2',
+              uses: 'actions/upload-artifact@v4',
               with: {
                 name: 'ProcessedDiffLogs',
                 path: '*.log',

--- a/test/__snapshots__/cdk-diff-workflow.test.ts.snap
+++ b/test/__snapshots__/cdk-diff-workflow.test.ts.snap
@@ -106,7 +106,7 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
       - name: Save processed diff logs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: ProcessedDiffLogs
           path: "*.log"
@@ -220,7 +220,7 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
       - name: Save processed diff logs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: ProcessedDiffLogs
           path: "*.log"
@@ -334,7 +334,7 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
       - name: Save processed diff logs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: ProcessedDiffLogs
           path: "*.log"
@@ -448,7 +448,7 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
       - name: Save processed diff logs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: ProcessedDiffLogs
           path: "*.log"
@@ -656,7 +656,7 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
       - name: Save processed diff logs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: ProcessedDiffLogs
           path: "*.log"
@@ -770,7 +770,7 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
       - name: Save processed diff logs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: ProcessedDiffLogs
           path: "*.log"
@@ -888,7 +888,7 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
       - name: Save processed diff logs
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: ProcessedDiffLogs
           path: "*.log"


### PR DESCRIPTION
Fixes #
- update GH artifact actions to v4

```typescript
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3.1.2`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
``` 