### PR TITLE
fix(renovate): ignore pnpm from being upgraded by renovate [CLK-616357]

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -72,6 +72,7 @@
     "jsii",
     "node",
     "@time-loop/clickup-projen",
+    "pnpm",
     "projen"
   ],
   "rangeStrategy": "bump",

--- a/src/renovate-workflow.ts
+++ b/src/renovate-workflow.ts
@@ -106,6 +106,7 @@ export module renovateWorkflow {
         ignore: [
           'node', // managed by projen
           '@time-loop/clickup-projen', // managed as part of the projen upgrade workflow
+          'pnpm', // managed by projen
         ],
         overrideConfig: {
           /* override projen renovate defaults */

--- a/test/__snapshots__/renovate-workflow.test.ts.snap
+++ b/test/__snapshots__/renovate-workflow.test.ts.snap
@@ -96,6 +96,7 @@ exports[`getRenovateOptions defaults 1`] = `
   "ignore": [
     "node",
     "@time-loop/clickup-projen",
+    "pnpm",
   ],
   "ignoreProjen": true,
   "labels": [


### PR DESCRIPTION
Tells renovate to ignore trying to update the pnpm version in the package.json as projen then just overrides it and we end up with renovate creating empty commits like so: https://github.com/time-loop/public-sharing-frontend-cdk/pull/121