### PR TITLE
fix(cdk-diff): REVERT github now requires metadata grant [INFRA-52676]

### DIFF
--- a/src/cdk-diff-workflow.ts
+++ b/src/cdk-diff-workflow.ts
@@ -28,7 +28,6 @@ export module cdkDiffWorkflow {
       permissions: {
         'id-token': 'write',
         contents: 'write',
-        metadata: 'write',
         'pull-requests': 'write',
       },
       jobs: {

--- a/test/__snapshots__/cdk-diff-workflow.test.ts.snap
+++ b/test/__snapshots__/cdk-diff-workflow.test.ts.snap
@@ -10,7 +10,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  metadata: write
   pull-requests: write
 jobs:
   diff:
@@ -125,7 +124,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  metadata: write
   pull-requests: write
 jobs:
   diff:
@@ -240,7 +238,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  metadata: write
   pull-requests: write
 jobs:
   diff:
@@ -355,7 +352,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  metadata: write
   pull-requests: write
 jobs:
   diff:
@@ -470,7 +466,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  metadata: write
   pull-requests: write
 jobs:
   diff:
@@ -679,7 +674,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  metadata: write
   pull-requests: write
 jobs:
   diff:
@@ -794,7 +788,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  metadata: write
   pull-requests: write
 jobs:
   diff:


### PR DESCRIPTION
This reverts commit 2699a273befeb1a8a03e0467d6802fcd0db64275.

Alas, I trusted GitHub CoPilot and it hallucinated.
