### PR TITLE
fix(renovate): update deprecated configuration options [INFRA-61273]

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,20 +7,18 @@
     "before 2am on Monday"
   ],
   "extends": [
-    "config:base",
+    "config:recommended",
     "group:recommended",
     "group:monorepos",
-    "github>whitesource/merge-confidence:beta"
+    "mergeConfidence:all-badges"
   ],
   "packageRules": [
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "excludePackagePatterns": [
-        "^@time-loop\\/clickup-projen"
+      "matchPackageNames": [
+        "*",
+        "!/^@time-loop\\/clickup-projen/"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -40,14 +38,14 @@
       ]
     },
     {
-      "matchPackagePatterns": [
-        "^@time-loop\\/clickup-projen"
+      "matchPackageNames": [
+        "/^@time-loop\\/clickup-projen/"
       ],
       "allowedVersions": "!/^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?-(alpha|beta).*$/"
     },
     {
-      "matchPackagePrefixes": [
-        "@time-loop/"
+      "matchPackageNames": [
+        "@time-loop/{/,}**"
       ],
       "matchUpdateTypes": [
         "major"

--- a/src/renovate-workflow.ts
+++ b/src/renovate-workflow.ts
@@ -112,19 +112,18 @@ export module renovateWorkflow {
           /* override projen renovate defaults */
           // Remove :preserveSemverRanges preset added by projen to make renovate update all non breaking dependencies
           extends: [
-            'config:base',
+            'config:recommended', // Updated from 'config:base'
             'group:recommended',
             'group:monorepos',
             // Add merge confidence columns to update PRs
-            'github>whitesource/merge-confidence:beta',
+            'mergeConfidence:all-badges', // Updated from 'github>whitesource/merge-confidence:beta'
           ],
           packageRules: [
             {
               // copied from this preset: https://docs.renovatebot.com/presets-group/#groupallnonmajor
               groupName: 'all non-major dependencies',
               groupSlug: 'all-minor-patch',
-              matchPackagePatterns: ['*'],
-              excludePackagePatterns: ['^@time-loop\\/clickup-projen'],
+              matchPackageNames: ['*', '!/^@time-loop\\/clickup-projen/'], // Updated from matchPackagePatterns and excludePackagePatterns
               matchUpdateTypes: ['minor', 'patch'],
               // Tell renovate to enable github's auto merge feature on the PR
               automerge: options.autoMergeNonBreakingUpdates ? true : undefined,
@@ -136,14 +135,14 @@ export module renovateWorkflow {
               addLabels: [OPTIONAL_RENOVATE_PR_LABEL],
             },
             {
-              matchPackagePatterns: ['^@time-loop\\/clickup-projen'],
+              matchPackageNames: ['/^@time-loop\\/clickup-projen/'], // Updated from matchPackagePatterns
               // Bypass prerelease versions:
               // https://docs.renovatebot.com/configuration-options/#allowedversions
               // Ex: 1.1.1 is allowed, 1.1.1-beta.0 is not allowed.
               allowedVersions: '!/^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?-(alpha|beta).*$/',
             },
             {
-              matchPackagePrefixes: ['@time-loop/'],
+              matchPackageNames: ['@time-loop/{/,}**'], // Updated from matchPackagePrefixes
               matchUpdateTypes: ['major'],
               prBodyNotes: [
                 '# DANGER WILL ROBINSON!!!',
@@ -153,7 +152,7 @@ export module renovateWorkflow {
             },
           ],
 
-          /* override defaults set in config:base preset */
+          /* override defaults set in config:recommended preset */
           // update all dependencies, not just major versions
           rangeStrategy: 'bump',
           // Create PRs for all updates in one go as we only run renovate once a week

--- a/test/__snapshots__/renovate-workflow.test.ts.snap
+++ b/test/__snapshots__/renovate-workflow.test.ts.snap
@@ -105,10 +105,10 @@ exports[`getRenovateOptions defaults 1`] = `
   "overrideConfig": {
     "automergeType": "pr",
     "extends": [
-      "config:base",
+      "config:recommended",
       "group:recommended",
       "group:monorepos",
-      "github>whitesource/merge-confidence:beta",
+      "mergeConfidence:all-badges",
     ],
     "packageRules": [
       {
@@ -116,13 +116,11 @@ exports[`getRenovateOptions defaults 1`] = `
           undefined,
         ],
         "automerge": undefined,
-        "excludePackagePatterns": [
-          "^@time-loop\\/clickup-projen",
-        ],
         "groupName": "all non-major dependencies",
         "groupSlug": "all-minor-patch",
-        "matchPackagePatterns": [
+        "matchPackageNames": [
           "*",
+          "!/^@time-loop\\/clickup-projen/",
         ],
         "matchUpdateTypes": [
           "minor",
@@ -139,13 +137,13 @@ exports[`getRenovateOptions defaults 1`] = `
       },
       {
         "allowedVersions": "!/^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?-(alpha|beta).*$/",
-        "matchPackagePatterns": [
-          "^@time-loop\\/clickup-projen",
+        "matchPackageNames": [
+          "/^@time-loop\\/clickup-projen/",
         ],
       },
       {
-        "matchPackagePrefixes": [
-          "@time-loop/",
+        "matchPackageNames": [
+          "@time-loop/{/,}**",
         ],
         "matchUpdateTypes": [
           "major",


### PR DESCRIPTION
Updates Renovate configuration to use current non-deprecated options:

- Replace 'config:base' with 'config:recommended' preset
- Replace 'github>whitesource/merge-confidence:beta' with 'mergeConfidence:all-badges'
- Replace matchPackagePatterns/excludePackagePatterns with matchPackageNames syntax
- Replace matchPackagePrefixes with matchPackageNames syntax
- Update comment references to reflect config:recommended usage

These deprecated options were causing "Config Migration Needed" warnings
that blocked Renovate from creating dependency update PRs in downstream
projects. This change aligns with Renovate's current configuration
schema and resolves the blocking migration issues.

Fixes dependency update blocking in field-service-cdk and other repos
using this configuration.
