### PR TITLE
feat(fe-eng-sys): defer 3rd party renovate PR upgrades for 7 days [CLK-808737]

### DIFF
--- a/src/renovate-workflow.ts
+++ b/src/renovate-workflow.ts
@@ -150,6 +150,11 @@ export module renovateWorkflow {
                 'CloudPlatform thanks you for being diligent with your library updates!',
               ],
             },
+            {
+              matchPackageNames: ['@time-loop/{/,}**'],
+              // Trust all internal packages
+              minimumReleaseAge: '0 days',
+            },
           ],
 
           /* override defaults set in config:recommended preset */
@@ -164,6 +169,8 @@ export module renovateWorkflow {
           automergeType: 'pr',
           // Use github's auto merge feature and not renovate's built in alternative
           platformAutomerge: true,
+          // Only consider dependencies that have been released for 7 days, to mimimize the risk of compromised packages being merged
+          minimumReleaseAge: '7 days',
         },
       },
       options.defaultOverrides ?? {


### PR DESCRIPTION
With this change, renovate will now only create dependency upgrade PRs after they have been released for 7 days to minimise the risk of compromised packages being published and causing major security issues

The exception is for our internal libs which we continue to release immediately